### PR TITLE
PR#10 を main に反映（PDF/EPUB 生成パイプライン）

### DIFF
--- a/.github/workflows/book-dist.yml
+++ b/.github/workflows/book-dist.yml
@@ -1,0 +1,52 @@
+name: book-dist
+
+on:
+  workflow_dispatch:
+  push:
+    tags: ["v*"]
+
+jobs:
+  build-dist:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install mdBook
+        uses: peaceiris/actions-mdbook@v2
+        with:
+          mdbook-version: "0.5.2"
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install mdBook plugins
+        run: |
+          cargo install mdbook-mermaid --version 0.17.0 --locked
+          cargo install mdbook-epub --version 0.4.48 --locked
+
+      - name: Ensure Chrome/Chromium is available
+        run: |
+          if command -v google-chrome >/dev/null 2>&1; then
+            google-chrome --version
+            exit 0
+          fi
+          if command -v chromium >/dev/null 2>&1; then
+            chromium --version
+            exit 0
+          fi
+          if command -v chromium-browser >/dev/null 2>&1; then
+            chromium-browser --version
+            exit 0
+          fi
+
+          sudo apt-get update
+          sudo apt-get install -y chromium-browser || sudo apt-get install -y chromium
+
+      - name: Build dist
+        run: bash scripts/build_dist.sh
+
+      - name: Upload dist artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: book-dist
+          path: dist

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # mdBook build output
 book/
+dist/
 
 # OS/editor noise
 .DS_Store
-

--- a/README.md
+++ b/README.md
@@ -133,6 +133,26 @@ GitHub Actions でも `mdbook build` を実行し、成果物（HTML）を Artif
 
 ---
 
+## 📦 PDF/EPUB 生成（暫定）
+
+PDF/EPUB の生成は `scripts/build_dist.sh` で行う（`dist/` に出力）。
+
+前提：
+
+- `mdbook-epub`（EPUB 生成）
+- Chrome/Chromium（PDF 生成）
+
+例：
+
+```bash
+cargo install mdbook-epub --version 0.4.48 --locked
+
+# dist/book.pdf と dist/book.epub を生成
+bash scripts/build_dist.sh
+```
+
+---
+
 ## 📌 現在のステータス
 
 * 書籍企画（ISSUE）作成済み

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -20,3 +20,7 @@ title: "演習補助スクリプト概要（scripts/）"
 
 これらのスクリプトは、本書の安全な演習方針（ローカル／許可された環境のみ）に沿って設計する。
 
+## 追加済みのスクリプト
+
+- `build_dist.sh`  
+  PDF/EPUB を生成し、`dist/` に配置する（`mdbook build` / `mdbook-epub` / Chrome/Chromium を利用）。

--- a/scripts/build_dist.sh
+++ b/scripts/build_dist.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+build_dir="${BUILD_DIR:-book}"
+dist_dir="${DIST_DIR:-dist}"
+
+pdf_output="${PDF_OUTPUT:-${dist_dir}/book.pdf}"
+epub_output="${EPUB_OUTPUT:-${dist_dir}/book.epub}"
+
+cd "$root_dir"
+mkdir -p "$dist_dir"
+
+mdbook build
+
+mdbook-epub --standalone "$root_dir"
+
+generated_epub_path="$(
+  ls -1 "${build_dir}"/*.epub 2>/dev/null | head -n 1 || true
+)"
+if [[ -z "${generated_epub_path}" ]]; then
+  echo "EPUB が見つかりません: ${build_dir}/*.epub" >&2
+  exit 1
+fi
+cp -f "${generated_epub_path}" "${epub_output}"
+
+pdf_browser="${PDF_BROWSER:-}"
+if [[ -z "${pdf_browser}" ]]; then
+  if command -v google-chrome >/dev/null 2>&1; then
+    pdf_browser="google-chrome"
+  elif command -v chromium >/dev/null 2>&1; then
+    pdf_browser="chromium"
+  elif command -v chromium-browser >/dev/null 2>&1; then
+    pdf_browser="chromium-browser"
+  else
+    echo "Chrome/Chromium が見つかりません（PDF 生成不可）" >&2
+    exit 1
+  fi
+fi
+
+print_html_path="${build_dir}/print.html"
+if [[ ! -f "${print_html_path}" ]]; then
+  echo "print.html が見つかりません: ${print_html_path}" >&2
+  exit 1
+fi
+
+"${pdf_browser}" \
+  --headless \
+  --disable-gpu \
+  --no-sandbox \
+  --print-to-pdf="${pdf_output}" \
+  "file://${root_dir}/${print_html_path}"
+
+echo "Wrote: ${epub_output}"
+echo "Wrote: ${pdf_output}"


### PR DESCRIPTION
PR #10（PDF/EPUB 生成パイプライン）が `chore/figures-mermaid` にマージされており、`main` に未反映だったため取り込みます。

- `scripts/build_dist.sh`（`dist/` への PDF/EPUB 出力）
- `.github/workflows/book-dist.yml`（タグ `v*` / 手動実行で dist を Artifact 化）
- `.gitignore` に `dist/` 追加
- `README.md` / `scripts/README.md` の手順追記
