### PR TITLE
Exercises: READMEと同梱ファイルの整合を修正

### DIFF
--- a/exercises/README.md
+++ b/exercises/README.md
@@ -6,14 +6,14 @@ title: "演習環境概要（exercises/）"
 
 `exercises/` ディレクトリは、本書の各 Part で利用する演習環境（主に Docker Compose ベース）の構成ファイルをまとめる場所である。
 
-## ディレクトリ構成（予定）
+## ディレクトリ構成（現状）
 
 - `exercises/juice-shop/`  
   OWASP Juice Shop 等を用いた Web 脆弱性演習用環境。
 - `exercises/dvwa/`  
   基礎的な Web 脆弱性（XSS、SQL インジェクション等）を確認する DVWA 環境。
 - `exercises/crapi/`  
-  API セキュリティ演習用の crAPI などを配置することを想定する。
+  API セキュリティ演習用の crAPI を用いた環境。
 
 各ディレクトリには、少なくとも次のファイルを配置する方針とする。
 

--- a/exercises/crapi/.env.example
+++ b/exercises/crapi/.env.example
@@ -1,6 +1,8 @@
-# 127.0.0.1 にバインドし、外部からアクセスできないようにする（推奨）
+# crAPI exercise environment (.env example)
+# NOTE: This file is optional; docker-compose.yml has safe defaults.
+
+# Bind published ports to localhost to avoid unintended exposure.
 LISTEN_IP=127.0.0.1
 
-# 取得する crAPI イメージのタグ（再現性・安全性のため固定を推奨）
-# NOTE: `latest` のような可変タグは、意図しない更新を避ける観点で非推奨とする。
+# Pin image versions for reproducibility.
 VERSION=1.1.6-rc8

--- a/exercises/crapi/README.md
+++ b/exercises/crapi/README.md
@@ -4,7 +4,7 @@ title: "crAPI 演習環境概要"
 
 # crAPI 演習環境概要
 
-本ディレクトリは、crAPI などを用いた API セキュリティ演習環境を配置することを想定している。
+本ディレクトリは、crAPI を用いた API セキュリティ演習環境を配置している。
 
 ## 目的
 
@@ -18,7 +18,7 @@ title: "crAPI 演習環境概要"
 - Docker Desktop などで Docker Engine が利用可能であること
 - `docker compose`（Compose v2）が利用可能であること
 
-推奨：`.env` を作成し、`LISTEN_IP=127.0.0.1` を明示する。
+推奨：`.env` を作成し、`LISTEN_IP=127.0.0.1` を明示する（`docker-compose.yml` 側にもデフォルト値はあるが、演習用途では明示しておくと安全である）。
 
 ```bash
 cp .env.example .env

--- a/exercises/dvwa/README.md
+++ b/exercises/dvwa/README.md
@@ -4,7 +4,7 @@ title: "DVWA 演習環境概要"
 
 # DVWA 演習環境概要
 
-本ディレクトリは、DVWA（Damn Vulnerable Web Application）を用いた基礎的な Web 脆弱性演習環境を配置することを想定している。
+本ディレクトリは、DVWA（Damn Vulnerable Web Application）を用いた基礎的な Web 脆弱性演習環境を配置している。
 
 ## 目的
 

--- a/exercises/juice-shop/README.md
+++ b/exercises/juice-shop/README.md
@@ -4,7 +4,7 @@ title: "Juice Shop 演習環境概要"
 
 # Juice Shop 演習環境概要
 
-本ディレクトリは、OWASP Juice Shop 等を用いた Web 脆弱性演習環境を配置することを想定している。
+本ディレクトリは、OWASP Juice Shop 等を用いた Web 脆弱性演習環境を配置している。
 
 ## 目的
 


### PR DESCRIPTION
演習環境の参照整合（exercises/）

- `exercises/crapi/README.md` が参照する `.env.example` を追加
- `exercises/README.md` と各演習 README の記述を「現状」に合わせて調整（想定→配置している）

Issue: #23
