### PR TITLE
Stage2: exercises/READMEにPart対応表を追加

### DIFF
--- a/exercises/README.md
+++ b/exercises/README.md
@@ -6,6 +6,21 @@ title: "演習環境概要（exercises/）"
 
 `exercises/` ディレクトリは、本書の各 Part で利用する演習環境（主に Docker Compose ベース）の構成ファイルをまとめる場所である。
 
+## 本文（Part）との対応（現状）
+
+本文の「対応演習」記載と、`exercises/` 配下の提供物の対応は次の通りである。
+
+| Part | 本文での「対応演習」記載（例） | `exercises/` 配下の提供状況（現状） |
+| --- | --- | --- |
+| Part 0：はじめに | `exercises/` 配下の環境で疎通確認（付録「演習環境クイックスタート」参照） | 提供あり（`juice-shop` / `dvwa` / `crapi`） |
+| Part 1：基礎理論 | ワークシート・観点整理中心（特定の演習環境に依存しない） | 該当なし |
+| Part 2：Web セキュリティ基盤 | `exercises/juice-shop/` / `exercises/dvwa/` | 提供あり（`juice-shop` / `dvwa`） |
+| Part 3：Web Pentest 実践 | `exercises/juice-shop/` / `exercises/dvwa/` / Burp Academy | 提供あり（`juice-shop` / `dvwa`）、Burp Academy は外部 |
+| Part 4：API Pentest と認証／権限管理 | `exercises/crapi/` | 提供あり（`crapi`） |
+| Part 5：モバイル Pentest | `exercises/` 配下に今後追加予定 | 未整備 |
+| Part 6：クラウド・インフラ Pentest | `exercises/` 配下に今後追加予定 | 未整備 |
+| Part 7：総合演習 | 既存の `exercises/` を前提にシナリオ設計 | Part 7 専用は未整備（既存の `dvwa` / `juice-shop` / `crapi` を利用） |
+
 ## ディレクトリ構成（現状）
 
 - `exercises/juice-shop/`  


### PR DESCRIPTION
## 目的
Stage2（構成レビュー/提供状況の明確化）の一環として、本文（Part）と `exercises/` 配下の演習環境の対応を一覧化します。

## 変更内容
- `exercises/README.md` に、各 Part の「対応演習」記載と提供状況の対応表を追加

## 補足
- 本文側の注記（演習未整備の明記）と参照整合を取りやすくするためのメタ情報です。
