### PR TITLE
Stage2: READMEから演習提供状況（対応表）へ誘導

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ pentest-learning-book/
 └── docs/               # 公開用ドキュメント（GitHub Pages 等）
 ```
 
+## 🧪 演習環境（exercises/）の提供状況
+
+本文（Part）ごとの「対応演習」と、`exercises/` 配下の提供物の対応は `exercises/README.md` の表を参照してください。
+
+執筆時点では Part 5（モバイル）/ Part 6（クラウド）/ Part 7（総合演習の専用シナリオ）について、`exercises/` 側の演習が未整備である点に留意してください。
+
 ---
 
 ## 🎯 想定読者


### PR DESCRIPTION
## 目的
Stage2（構成レビュー/読者導線）の一環として、README から演習環境の提供状況（Partとの対応表）へ誘導します。

## 変更内容
- `README.md` に「演習環境（exercises/）の提供状況」セクションを追加
- `exercises/README.md` の対応表を参照する導線を追加

## 補足
- 本文側の注記（演習未整備の明記）と整合するよう、現状の未整備Part（5/6/7）をREADME側でも明示しています。
