### PR TITLE
Docs: clarify Reconnaissance label

### DIFF
--- a/figures/fig_part3_web_pentest_workflow.mmd
+++ b/figures/fig_part3_web_pentest_workflow.mmd
@@ -1,6 +1,6 @@
 ```mermaid
 flowchart TB
-    Recon[1. 情報収集（Recon）\nProxy + ブラウザ操作] --> Auth[2. 認証/セッション確認\nCookie・ログイン挙動]
+    Recon[1. 情報収集（Reconnaissance）\nProxy + ブラウザ操作] --> Auth[2. 認証/セッション確認\nCookie・ログイン挙動]
     Auth --> Surface[3. アタックサーフェス整理\nTarget（サイトマップ）]
     Surface --> Hypo[4. 仮説に基づく検証\nRepeater / Intruder]
     Hypo --> Findings[5. 発見事項の整理・評価\n優先度付け]


### PR DESCRIPTION
## 目的
Part 3 のワークフロー図における用語表記（Recon）を、本文の表記に合わせて明確化する。

## 変更点
- 図3-2：`Recon` 表記を `Reconnaissance` に変更

## 確認
- `mdbook build` 実行済み（警告: mdbook-mermaid 0.5.0 vs mdbook 0.5.2）

Refs #23
