### PR TITLE
Docs: expand AWS glossary abbreviations

### DIFF
--- a/manuscript/appendix/glossary.md
+++ b/manuscript/appendix/glossary.md
@@ -146,11 +146,11 @@
 ## クラウド・インフラ
 
 - AWS  
-  クラウドサービス。本書では IAM/VPC/S3/IMDS を中心に扱う。
+  クラウドサービス。本書では IAM / VPC / S3 / IMDS を中心に扱う。
 - IAM（Identity and Access Management）  
   AWS の認証・認可の中核。ユーザ／ロール／ポリシーにより権限を制御する。
 - VPC（Virtual Private Cloud）  
-  AWS 上の仮想ネットワーク。サブネット、ルート、IGW/NAT、セキュリティグループ等で構成される。
+  AWS 上の仮想ネットワーク。サブネット、ルートテーブル、インターネットゲートウェイ（IGW）、NAT ゲートウェイ、セキュリティグループ等で構成される。
 - S3  
   オブジェクトストレージ。公開設定やアクセス制御の誤りが情報漏えいに直結する。
 - SSRF（Server-Side Request Forgery）  


### PR DESCRIPTION
### 変更概要

- `manuscript/appendix/glossary.md`：AWS/VPC の説明で略語（IGW など）を展開し、`IAM/VPC/S3/IMDS` を本文側の表記（`IAM / VPC / S3 / IMDS`）に統一

### 補足

- 用語の補足のみ（技術主張の追加なし）。
