### PR TITLE
Docs: rename API Attack Surface chapter title

### DIFF
--- a/manuscript/SUMMARY.md
+++ b/manuscript/SUMMARY.md
@@ -24,7 +24,7 @@
   - [PortSwigger Academy を使ったハンズオン](part3_burp/34_burp_academy_hands_on.md)
 
 - [Part 4：API Pentest と認証／権限管理](part4_api/40_overview.md)
-  - [API の基礎と攻撃面の整理](part4_api/41_api_basics_and_attack_surface.md)
+  - [API の基礎とアタックサーフェスの整理](part4_api/41_api_basics_and_attack_surface.md)
   - [典型的な API 脆弱性](part4_api/42_common_api_vulnerabilities.md)
   - [OAuth2 / OIDC / 外部 ID 連携のテスト](part4_api/43_oauth_oidc_testing.md)
   - [RBAC / ABAC の誤実装パターン](part4_api/44_rbac_abac_misconfig.md)

--- a/manuscript/part4_api/40_overview.md
+++ b/manuscript/part4_api/40_overview.md
@@ -38,7 +38,7 @@ API Security Top 10 で定義されるような代表的リスクをベースに
 
 ## 次に読む章
 
-- [API の基礎と攻撃面の整理](41_api_basics_and_attack_surface.md)
+- [API の基礎とアタックサーフェスの整理](41_api_basics_and_attack_surface.md)
 
 ## 本章のポイント
 

--- a/manuscript/part4_api/41_api_basics_and_attack_surface.md
+++ b/manuscript/part4_api/41_api_basics_and_attack_surface.md
@@ -1,10 +1,10 @@
 ---
-title: "API の基礎と攻撃面の整理"
+title: "API の基礎とアタックサーフェスの整理"
 part: "Part 4"
 chapter: "4-1"
 ---
 
-# API の基礎と攻撃面の整理
+# API の基礎とアタックサーフェスの整理
 
 本章では、REST 形式を中心とした API の構造と、Pentest におけるアタックサーフェス（攻撃面 / Attack Surface）の整理方法を扱う。
 


### PR DESCRIPTION
## 変更概要
- Part4 の章タイトル（41 章）を「攻撃面」から「アタックサーフェス」表記に統一
- `manuscript/SUMMARY.md` と Part4 概要のリンクテキストを追従

## 確認
- `mdbook build` 成功（既知の mdbook-mermaid 警告は継続）

Relates to #23