### PR TITLE
Exercises: add MobSF environment

### DIFF
--- a/exercises/README.md
+++ b/exercises/README.md
@@ -17,7 +17,7 @@ title: "演習環境概要（exercises/）"
 | Part 2：Web セキュリティ基盤 | `exercises/juice-shop/` / `exercises/dvwa/` | 提供あり（`juice-shop` / `dvwa`） |
 | Part 3：Web Pentest 実践 | `exercises/juice-shop/` / `exercises/dvwa/` / Burp Academy | 提供あり（`juice-shop` / `dvwa`）、Burp Academy は外部 |
 | Part 4：API Pentest と認証／権限管理 | `exercises/crapi/` | 提供あり（`crapi`） |
-| Part 5：モバイル Pentest | `exercises/` 配下に今後追加予定 | 未整備 |
+| Part 5：モバイル Pentest | MobSF 等を用いた静的解析 | 提供あり（`mobsf`）※解析対象アプリは別途用意 |
 | Part 6：クラウド・インフラ Pentest | `exercises/` 配下に今後追加予定 | 未整備 |
 | Part 7：総合演習 | 既存の `exercises/` を前提にシナリオ設計 | Part 7 専用は未整備（既存の `dvwa` / `juice-shop` / `crapi` を利用） |
 
@@ -29,6 +29,8 @@ title: "演習環境概要（exercises/）"
   基礎的な Web 脆弱性（XSS、SQL インジェクション等）を確認する DVWA 環境。
 - `exercises/crapi/`  
   API セキュリティ演習用の crAPI を用いた環境。
+- `exercises/mobsf/`  
+  MobSF（Mobile Security Framework）を用いたモバイル静的解析の演習環境。
 
 各ディレクトリには、少なくとも次のファイルを配置する方針とする。
 

--- a/exercises/mobsf/README.md
+++ b/exercises/mobsf/README.md
@@ -1,0 +1,35 @@
+---
+title: "MobSF 演習環境（exercises/mobsf）"
+---
+
+# MobSF 演習環境（Part 5）
+
+本ディレクトリは、モバイルアプリの静的解析・簡易動的解析に利用する MobSF（Mobile Security Framework）を、ローカル環境で起動するための演習環境である。
+
+## 前提
+
+- Docker Engine と `docker compose`（Compose v2）が利用可能であること。
+- 演習対象は **許可された検証用アプリ（演習用アプリ）** に限定すること。
+
+## 起動
+
+```bash
+cd exercises/mobsf
+docker compose up -d
+```
+
+起動後、ブラウザで以下にアクセスする。
+
+- `http://127.0.0.1:8000/`
+
+## 停止
+
+```bash
+cd exercises/mobsf
+docker compose down
+```
+
+## 補足
+
+- MobSF の UI や機能はバージョンにより変化する。本文は特定 UI に依存せず、確認観点を中心に扱う。
+- 本番アプリや第三者のアプリに対して、無断で解析や攻撃的操作を行ってはならない。

--- a/exercises/mobsf/docker-compose.yml
+++ b/exercises/mobsf/docker-compose.yml
@@ -1,0 +1,6 @@
+services:
+  mobsf:
+    image: opensecurity/mobile-security-framework-mobsf:latest
+    ports:
+      - "127.0.0.1:8000:8000"
+    restart: unless-stopped


### PR DESCRIPTION
## 変更概要
- Part5 向けに MobSF 起動用の演習環境を追加（`exercises/mobsf`）
- `exercises/README.md` の対応表とディレクトリ一覧を更新

## 目的
- Part5（モバイル）で参照できる最低限の演習実行基盤（MobSF）を用意する

Relates to #23