### PR TITLE
Docs: add recommended deliverables to Part4 overview

### DIFF
--- a/manuscript/part4_api/40_overview.md
+++ b/manuscript/part4_api/40_overview.md
@@ -30,6 +30,15 @@ API Security Top 10 で定義されるような代表的リスクをベースに
 演習環境としては、`exercises/crapi/` に配置する API 演習環境を用い、OpenAPI 仕様と実際のトラフィックを付き合わせながら、BOLA や Mass Assignment などの API 特有の脆弱性を確認することを想定する。
 観察結果は [学習ログテンプレート（Burp Academy / 演習）](../appendix/templates_learning_log.md) に従って記録する。
 
+## 演習で作る成果物（推奨）
+
+演習では、次の成果物を作ると後続（攻撃チェーン整理・レポート作成）に接続しやすい。
+
+- API エンドポイント一覧（OpenAPI 仕様と実トラフィックの照合結果）
+- 権限差分メモ（ロール／所有者／スコープごとのレスポンス差分）
+- 学習ログ（BOLA / Mass Assignment / Rate Limit の成立条件と証拠）
+- PoC の下書き（再現手順・証拠・影響・推奨対策の要点）
+
 ## 関連資料
 
 - [付録「演習環境クイックスタート」](../appendix/exercises_quickstart.md)


### PR DESCRIPTION
概要
- ISSUE #110 の「演習タスク/期待アウトプット」補強として、Part4 概要章に「演習で作る成果物（推奨）」セクションを追加します。

変更点
- 4-0 章: エンドポイント一覧、権限差分メモ、学習ログ、PoC 下書きの推奨成果物を明記

確認
- mdbook build をローカルで実行して成功

Refs: #110
