### PR TITLE
付録: 演習環境クイックスタートの導線を補強

### DIFF
--- a/manuscript/appendix/exercises_quickstart.md
+++ b/manuscript/appendix/exercises_quickstart.md
@@ -2,6 +2,8 @@
 
 本付録は、`exercises/` 配下の演習環境（DVWA / Juice Shop / crAPI / MobSF / SSRF→IMDS）を「起動 → 疎通確認 → 停止」まで最短で進めるための導線をまとめる。詳細な注意事項や補足は、各ディレクトリの `README.md` を参照する。
 
+演習の結果は、後続（PoC 作成・レポート作成）に接続できるよう、付録『[学習ログテンプレート（Burp Academy / 演習）](templates_learning_log.md)』に従って記録することを推奨する。
+
 ## スクリプトで実行する場合（推奨）
 
 演習環境の起動・停止は、`scripts/` 配下の補助スクリプトでも実行できる。
@@ -27,6 +29,7 @@ bash scripts/cleanup_exercises.sh dvwa
 ## Juice Shop（Part 2〜3）
 
 - ディレクトリ：`exercises/juice-shop/`
+- 対応章：[Part 2：Web セキュリティ基盤](../part2_web/20_overview.md)、[Part 3：Web Pentest 実践](../part3_burp/30_overview.md)
 - 起動：
 
 ```bash
@@ -44,6 +47,7 @@ docker compose down
 ## DVWA（Part 2〜3）
 
 - ディレクトリ：`exercises/dvwa/`
+- 対応章：[Part 2：Web セキュリティ基盤](../part2_web/20_overview.md)、[Part 3：Web Pentest 実践](../part3_burp/30_overview.md)
 - 起動：
 
 ```bash
@@ -63,6 +67,7 @@ docker compose down
 ## crAPI（Part 4）
 
 - ディレクトリ：`exercises/crapi/`
+- 対応章：[Part 4：API Pentest と認証／権限管理](../part4_api/40_overview.md)
 - 事前準備（推奨）：`.env` を作成し、`LISTEN_IP=127.0.0.1` を明示する。
 
 ```bash
@@ -91,6 +96,8 @@ docker compose down
 ## MobSF（Part 5）
 
 - ディレクトリ：`exercises/mobsf/`
+- 対応章：[Part 5：モバイル Pentest](../part5_mobile/50_overview.md)
+- 補足：解析対象の APK / IPA は本リポジトリに同梱しないため、許可された検証用アプリを別途用意する。
 - 起動：
 
 ```bash
@@ -108,6 +115,8 @@ docker compose down
 ## SSRF→IMDS（Part 6）
 
 - ディレクトリ：`exercises/ssrf-imds/`
+- 対応章：[Part 6：クラウド・インフラ Pentest](../part6_cloud/60_overview.md)
+- 補足：演習はローカル完結で行い、`url` パラメータを用いて第三者システムへの URL フェッチを試行しないこと。
 - 起動：
 
 ```bash


### PR DESCRIPTION
## 変更内容
- 付録「演習環境クイックスタート」に、対応章リンクと学習ログ記録の導線を追加しました。
- MobSF（解析対象アプリは別途用意）と SSRF→IMDS（第三者URLへ向けない）の補足を追記しました。

## 背景
- Refs: #110（演習と本文の接続・成果物導線の改善）

## 確認
- `mdbook build`（mdbook 0.5.2）
  - `mdbook-mermaid` のバージョン差分警告は既知で、ビルド自体は成功します。
