### PR TITLE
Part3: 本章のゴール（対応演習）を読みやすく整形

### DIFF
--- a/manuscript/part3_burp/31_burpsuite_basics.md
+++ b/manuscript/part3_burp/31_burpsuite_basics.md
@@ -12,7 +12,8 @@ chapter: "3-1"
 
 - 前提：Part 2 で HTTP / Cookie / セッション管理の基礎を把握している。
 - 到達目標：Burp Suite の主要コンポーネント（Proxy / Target / Repeater / Intruder 等）と、基本セットアップ（プロキシ、CA 証明書、スコープ設定）の要点を説明できる。
-- 対応演習：`exercises/juice-shop/` または `exercises/dvwa/` を Burp Suite 経由で操作し、HTTPS 復号とサイトマップ取得、重要リクエストの Repeater 保存を試す（起動手順は [付録「演習環境クイックスタート」](../appendix/exercises_quickstart.md) を参照。観察結果は [学習ログテンプレート（Burp Academy / 演習）](../appendix/templates_learning_log.md) に記録する）。
+- 対応演習：`exercises/juice-shop/` または `exercises/dvwa/` を Burp Suite 経由で操作し、HTTPS 復号とサイトマップ取得、重要リクエストの Repeater 保存を試す。  
+  起動手順は [付録「演習環境クイックスタート」](../appendix/exercises_quickstart.md) を参照し、観察結果は [学習ログテンプレート（Burp Academy / 演習）](../appendix/templates_learning_log.md) に記録する。
 
 ## Burp Suite の位置づけ
 

--- a/manuscript/part3_burp/32_web_pentest_workflow.md
+++ b/manuscript/part3_burp/32_web_pentest_workflow.md
@@ -12,7 +12,8 @@ chapter: "3-2"
 
 - 前提：Burp Suite の基本操作とセットアップ（前章）を完了している。
 - 到達目標：情報収集、アタックサーフェス整理、仮説立案、検証、結果整理を一連のワークフローとして説明し、再現性を意識して運用できる。
-- 対応演習：`exercises/juice-shop/` または `exercises/dvwa/` を対象に、Target でサイトマップを整理し、重要操作を Repeater に保存した上で、仮説ベースでパラメータを変更して挙動差分を記録する（起動手順は [付録「演習環境クイックスタート」](../appendix/exercises_quickstart.md) を参照。観察結果は [学習ログテンプレート（Burp Academy / 演習）](../appendix/templates_learning_log.md) に記録する）。
+- 対応演習：`exercises/juice-shop/` または `exercises/dvwa/` を対象に、Target でサイトマップを整理し、重要操作を Repeater に保存した上で、仮説ベースでパラメータを変更して挙動差分を記録する。  
+  起動手順は [付録「演習環境クイックスタート」](../appendix/exercises_quickstart.md) を参照し、観察結果は [学習ログテンプレート（Burp Academy / 演習）](../appendix/templates_learning_log.md) に記録する。
 
 図3-2: Web Pentest ワークフロー（概要）
 

--- a/manuscript/part3_burp/33_poc_and_reporting.md
+++ b/manuscript/part3_burp/33_poc_and_reporting.md
@@ -12,7 +12,8 @@ chapter: "3-3"
 
 - 前提：対象機能の挙動差分が取れており、再現可能なリクエストを Repeater 等に保存している。
 - 到達目標：PoC を「最小限・再現可能・本番影響を最小化」の原則で整理し、レポートではリスクシナリオと影響（ビジネスインパクト）まで含めて説明できる。
-- 対応演習：`exercises/juice-shop/` または `exercises/dvwa/` で発見した挙動を 1 件選び、再現手順・証拠（リクエスト／レスポンス）・推奨対策を PoC としてまとめる（起動手順は [付録「演習環境クイックスタート」](../appendix/exercises_quickstart.md) を参照。まとめ方は [Pentest レポートテンプレート](../appendix/templates_pentest_report.md) を参照）。
+- 対応演習：`exercises/juice-shop/` または `exercises/dvwa/` で発見した挙動を 1 件選び、再現手順・証拠（リクエスト／レスポンス）・推奨対策を PoC としてまとめる。  
+  起動手順は [付録「演習環境クイックスタート」](../appendix/exercises_quickstart.md) を参照し、まとめ方は [Pentest レポートテンプレート](../appendix/templates_pentest_report.md) を参照する。
 
 ## PoC の基本方針
 


### PR DESCRIPTION
## 変更内容
- Part 3（3-1〜3-3）の「本章のゴール」内にある対応演習の記述を改行し、読みやすさを改善しました（内容変更なし）。

## 背景
- Refs: #110（章内の読みやすさ・導線改善）

## 確認
- `mdbook build`（mdbook 0.5.2）
  - `mdbook-mermaid` のバージョン差分警告は既知で、ビルド自体は成功します。
