### PR TITLE
Part2: 本章のゴール（対応演習）を読みやすく整形

### DIFF
--- a/manuscript/part2_web/21_http_cookie_cors_samesite.md
+++ b/manuscript/part2_web/21_http_cookie_cors_samesite.md
@@ -12,7 +12,8 @@ chapter: "2-1"
 
 - 前提：HTTP リクエスト／レスポンス、ステータスコードの概念を理解している（Part 2 の前提範囲）。
 - 到達目標：Cookie の主要属性（`Domain` / `Path` / `Secure` / `HttpOnly` / `SameSite`）と、CORS の基本動作・典型的な誤設定を説明できる。
-- 対応演習：`exercises/juice-shop/` または `exercises/dvwa/` を Burp Suite 経由で操作し、`Set-Cookie` と CORS 関連ヘッダの挙動を観察する（起動手順は [付録「演習環境クイックスタート」](../appendix/exercises_quickstart.md) を参照。観察結果は [学習ログテンプレート（Burp Academy / 演習）](../appendix/templates_learning_log.md) に記録する）。
+- 対応演習：`exercises/juice-shop/` または `exercises/dvwa/` を Burp Suite 経由で操作し、`Set-Cookie` と CORS 関連ヘッダの挙動を観察する。  
+  起動手順は [付録「演習環境クイックスタート」](../appendix/exercises_quickstart.md) を参照し、観察結果は [学習ログテンプレート（Burp Academy / 演習）](../appendix/templates_learning_log.md) に記録する。
 
 ## HTTP の基本
 

--- a/manuscript/part2_web/22_session_and_csrf.md
+++ b/manuscript/part2_web/22_session_and_csrf.md
@@ -12,7 +12,8 @@ chapter: "2-2"
 
 - 前提：Cookie ベースの認証とセッションの概念、および SameSite の概要（前章）を把握している。
 - 到達目標：セッション管理の確認観点（再発行、無効化、タイムアウト等）と、CSRF の成立条件・代表的対策を説明できる。
-- 対応演習：`exercises/dvwa/` などで、ログイン前後の Cookie 変化や、CSRF 対策（トークン、SameSite 等）の有無を確認する（起動手順は [付録「演習環境クイックスタート」](../appendix/exercises_quickstart.md) を参照。観察結果は [学習ログテンプレート（Burp Academy / 演習）](../appendix/templates_learning_log.md) に記録する）。
+- 対応演習：`exercises/dvwa/` などで、ログイン前後の Cookie 変化や、CSRF 対策（トークン、SameSite 等）の有無を確認する。  
+  起動手順は [付録「演習環境クイックスタート」](../appendix/exercises_quickstart.md) を参照し、観察結果は [学習ログテンプレート（Burp Academy / 演習）](../appendix/templates_learning_log.md) に記録する。
 
 ## セッション管理の基本
 

--- a/manuscript/part2_web/24_common_web_vulnerabilities.md
+++ b/manuscript/part2_web/24_common_web_vulnerabilities.md
@@ -12,7 +12,8 @@ chapter: "2-4"
 
 - 前提：HTTP / Cookie / セッション / トークンの基礎（本 Part 前半）を把握している。
 - 到達目標：代表的な脆弱性（XSS、インジェクション、認可不備、SSRF 等）について、成立の前提をプロトコル視点で説明できる。
-- 対応演習：`exercises/juice-shop/` や `exercises/dvwa/` で、各脆弱性が成立する入口と「どのリクエストが変わると挙動が変わるか」を観察する（起動手順は [付録「演習環境クイックスタート」](../appendix/exercises_quickstart.md) を参照。観察結果は [学習ログテンプレート（Burp Academy / 演習）](../appendix/templates_learning_log.md) に記録する。具体手順は Part 3 以降で扱う）。
+- 対応演習：`exercises/juice-shop/` や `exercises/dvwa/` で、各脆弱性が成立する入口と「どのリクエストが変わると挙動が変わるか」を観察する。  
+  起動手順は [付録「演習環境クイックスタート」](../appendix/exercises_quickstart.md) を参照し、観察結果は [学習ログテンプレート（Burp Academy / 演習）](../appendix/templates_learning_log.md) に記録する。具体手順は Part 3 以降で扱う。
 
 図2-5 は、本章で扱う代表的な脆弱性クラスを「どの通信・処理の境界で起きる問題か」という観点で対応付けた概要図である。以降は、各脆弱性について「入力」「出力」「権限」「サーバ側リクエスト」といった観点で成立条件を整理する。
 


### PR DESCRIPTION
## 変更内容
- Part 2（2-1/2-2/2-4）の「本章のゴール」内にある対応演習の記述を改行し、読みやすさを改善しました（内容変更なし）。

## 背景
- Refs: #110（章内の読みやすさ・導線改善）

## 確認
- `mdbook build`（mdbook 0.5.2）
  - `mdbook-mermaid` のバージョン差分警告は既知で、ビルド自体は成功します。
