### PR TITLE
Part4: 本章のゴール（対応演習）を読みやすく整形

### DIFF
--- a/manuscript/part4_api/41_api_basics_and_attack_surface.md
+++ b/manuscript/part4_api/41_api_basics_and_attack_surface.md
@@ -12,7 +12,8 @@ chapter: "4-1"
 
 - 前提：Part 2 の HTTP / JWT / OAuth2 / OIDC の基礎と、Part 3 の Burp Suite を用いたワークフローの概要を把握している。
 - 到達目標：API の基本要素とアタックサーフェスの 3 観点（エンドポイント／データモデル／環境・インフラ）を説明し、OpenAPI 仕様と実トラフィックを使ってテスト対象を整理できる。
-- 対応演習：`exercises/crapi/` を対象に Burp Suite で API トラフィックを取得し、OpenAPI 仕様（存在する場合）と照合してエンドポイント一覧とテスト観点を作成する（起動手順は [付録「演習環境クイックスタート」](../appendix/exercises_quickstart.md) を参照。観察結果は [学習ログテンプレート（Burp Academy / 演習）](../appendix/templates_learning_log.md) に記録する）。
+- 対応演習：`exercises/crapi/` を対象に Burp Suite で API トラフィックを取得し、OpenAPI 仕様（存在する場合）と照合してエンドポイント一覧とテスト観点を作成する。  
+  起動手順は [付録「演習環境クイックスタート」](../appendix/exercises_quickstart.md) を参照し、観察結果は [学習ログテンプレート（Burp Academy / 演習）](../appendix/templates_learning_log.md) に記録する。
 
 ## API の基本要素
 

--- a/manuscript/part4_api/42_common_api_vulnerabilities.md
+++ b/manuscript/part4_api/42_common_api_vulnerabilities.md
@@ -12,7 +12,8 @@ chapter: "4-2"
 
 - 前提：API のアタックサーフェス（前章）を整理でき、Burp Suite 等で API リクエストを再現できる。
 - 到達目標：BOLA / Mass Assignment / Rate Limit 不備などの成立条件と検証方針を説明し、仕様と実装の差分からリスクを特定できる。
-- 対応演習：`exercises/crapi/` を対象に、ID パラメータの変更、想定外フィールドの追加、認証系エンドポイントのレート制限確認などを、合意された範囲で実施し、成立条件を記録する（起動手順は [付録「演習環境クイックスタート」](../appendix/exercises_quickstart.md) を参照。観察結果は [学習ログテンプレート（Burp Academy / 演習）](../appendix/templates_learning_log.md) に記録する）。
+- 対応演習：`exercises/crapi/` を対象に、ID パラメータの変更、想定外フィールドの追加、認証系エンドポイントのレート制限確認などを、合意された範囲で実施し、成立条件を記録する。  
+  起動手順は [付録「演習環境クイックスタート」](../appendix/exercises_quickstart.md) を参照し、観察結果は [学習ログテンプレート（Burp Academy / 演習）](../appendix/templates_learning_log.md) に記録する。
 
 ## BOLA（Broken Object Level Authorization）
 

--- a/manuscript/part4_api/43_oauth_oidc_testing.md
+++ b/manuscript/part4_api/43_oauth_oidc_testing.md
@@ -12,7 +12,8 @@ chapter: "4-3"
 
 - 前提：OAuth2 / OIDC の基本ロールと Authorization Code + PKCE の流れ（Part 2）を説明できる。
 - 到達目標：リダイレクト URI、スコープ、トークン検証、ログアウト／セッション連携などの観点で、実装のリスクを体系的に点検できる。
-- 対応演習：OAuth2 / OIDC を利用している演習環境がある場合、認可フローのトラフィックを Burp Suite で観察し、`redirect_uri`／スコープ／トークンのクレーム検証に関する挙動を整理する（観察結果は [学習ログテンプレート（Burp Academy / 演習）](../appendix/templates_learning_log.md) に記録する）。
+- 対応演習：OAuth2 / OIDC を利用している演習環境がある場合、認可フローのトラフィックを Burp Suite で観察し、`redirect_uri`／スコープ／トークンのクレーム検証に関する挙動を整理する。  
+  観察結果は [学習ログテンプレート（Burp Academy / 演習）](../appendix/templates_learning_log.md) に記録する。
 
 ## テスト対象の整理
 

--- a/manuscript/part4_api/44_rbac_abac_misconfig.md
+++ b/manuscript/part4_api/44_rbac_abac_misconfig.md
@@ -12,7 +12,8 @@ chapter: "4-4"
 
 - 前提：認証と認可の切り分け（Part 2）と、API の典型リスク（BOLA 等）を把握している。
 - 到達目標：RBAC / ABAC の誤実装パターンを説明し、複数アカウントでの差分比較を中心にアクセス制御の欠落を検証できる。
-- 対応演習：`exercises/crapi/` 等で複数ロール／複数ユーザを用意し、同一 API のレスポンス差分を比較して、アクセス制御の成立条件（所有者・ロール・スコープ等）を整理する（起動手順は [付録「演習環境クイックスタート」](../appendix/exercises_quickstart.md) を参照。観察結果は [学習ログテンプレート（Burp Academy / 演習）](../appendix/templates_learning_log.md) に記録する）。
+- 対応演習：`exercises/crapi/` 等で複数ロール／複数ユーザを用意し、同一 API のレスポンス差分を比較して、アクセス制御の成立条件（所有者・ロール・スコープ等）を整理する。  
+  起動手順は [付録「演習環境クイックスタート」](../appendix/exercises_quickstart.md) を参照し、観察結果は [学習ログテンプレート（Burp Academy / 演習）](../appendix/templates_learning_log.md) に記録する。
 
 ## RBAC / ABAC の概要
 


### PR DESCRIPTION
## 変更内容
- Part 4（4-1〜4-4）の「本章のゴール」内にある対応演習の記述を改行し、読みやすさを改善しました（内容変更なし）。

## 背景
- Refs: #110（章内の読みやすさ・導線改善）

## 確認
- `mdbook build`（mdbook 0.5.2）
  - `mdbook-mermaid` のバージョン差分警告は既知で、ビルド自体は成功します。
