### PR TITLE
Chore: align Pages workflow with docs/Jekyll

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -17,6 +17,8 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
     steps:
       - uses: actions/checkout@v4
 
@@ -25,16 +27,60 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          code="$(curl -sS -o /dev/null -w "%{http_code}" \
+          tmp="$(mktemp)"
+          code="$(curl -sS -o "$tmp" -w "%{http_code}" \
             -H "Authorization: Bearer $GITHUB_TOKEN" \
             -H "Accept: application/vnd.github+json" \
             "https://api.github.com/repos/${GITHUB_REPOSITORY}/pages")"
-          if [ "$code" = "200" ]; then
-            echo "enabled=true" >> "$GITHUB_OUTPUT"
+
+          if [ "$code" != "200" ]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "GitHub Pages is not enabled (HTTP $code). Skipping deploy."
+            rm -f "$tmp"
             exit 0
           fi
-          echo "enabled=false" >> "$GITHUB_OUTPUT"
-          echo "GitHub Pages is not enabled (HTTP $code). Skipping deploy."
+
+          build_type="$(python3 - "$tmp" <<'PY'
+          import json
+          import sys
+
+          with open(sys.argv[1], encoding="utf-8") as fh:
+              data = json.load(fh)
+
+          print(data.get("build_type", ""))
+          PY
+          )"
+          source_branch="$(python3 - "$tmp" <<'PY'
+          import json
+          import sys
+
+          with open(sys.argv[1], encoding="utf-8") as fh:
+              data = json.load(fh)
+
+          source = data.get("source") or {}
+          print(source.get("branch", ""))
+          PY
+          )"
+          source_path="$(python3 - "$tmp" <<'PY'
+          import json
+          import sys
+
+          with open(sys.argv[1], encoding="utf-8") as fh:
+              data = json.load(fh)
+
+          source = data.get("source") or {}
+          print(source.get("path", ""))
+          PY
+          )"
+          rm -f "$tmp"
+
+          if [ "$build_type" != "workflow" ]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "GitHub Pages is configured as build_type=${build_type} (source=${source_branch}${source_path}). Skipping GitHub Actions deploy."
+            exit 0
+          fi
+
+          echo "enabled=true" >> "$GITHUB_OUTPUT"
 
       - name: Check canonical files
         if: steps.pages.outputs.enabled == 'true'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,12 @@
 5. レビュー・調整
 6. マージ
 
+## 📦 本文編集と GitHub Pages（docs/）
+
+- 書籍本文は原則 `manuscript/` を編集する（`docs/part*/` と `docs/appendix/` は生成物として扱う）。
+- 本文を更新した場合は、`python3 scripts/sync_docs_from_manuscript.py` を実行し、`docs/` 側へ同期する。
+- 変更後は `mdbook build` でビルドが通ることを確認する（CI でも確認される）。
+
 ## 📝 ライセンス同意
 
 コントリビューションを行うことで、以下に同意したものとみなす：

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ pentest-learning-book/
 ├── project-management/ # 執筆・編集・出版の運用ドキュメント
 ├── roadmap/            # 学習パス（読み進め方のガイド）
 ├── reports/            # 品質管理レポート（必要に応じて）
-└── docs/               # 公開用ドキュメント（GitHub Pages 等）
+└── docs/               # 公開用ドキュメント（GitHub Pages/Jekyll）
 ```
 
 ## 演習環境（exercises/）の提供状況
@@ -168,6 +168,19 @@ mdbook serve
 ```
 
 GitHub Actions でも `mdbook build` を実行し、成果物（HTML）を Artifact として保存する。
+
+---
+
+## GitHub Pages（docs/）
+
+執筆時点の設定では、GitHub Pages は `docs/` をソースとしてビルドされる（Jekyll）。  
+本文（`manuscript/`）を更新した場合は、次のコマンドで `docs/` 側へ同期する。
+
+```bash
+python3 scripts/sync_docs_from_manuscript.py
+```
+
+原則として、書籍本文に対応する `docs/part*/` と `docs/appendix/` は同期スクリプトで生成する（手編集しない）。
 
 ---
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -16,6 +16,9 @@ title: "演習補助スクリプト概要（scripts/）"
 - `cleanup_exercises.sh`  
   演習環境（DVWA / Juice Shop / crAPI / MobSF / SSRF→IMDS / Linux/コンテナ）を停止する。  
   例：`bash scripts/cleanup_exercises.sh --all`
+- `sync_docs_from_manuscript.py`  
+  `manuscript/` の内容を `docs/`（GitHub Pages/Jekyll 用）へ同期する。`{{#include}}` の展開や Mermaid 図の変換を行う。  
+  例：`python3 scripts/sync_docs_from_manuscript.py`
 - `check_canonical_files.sh`  
   ルートの `LICENSE.md` / `THIRD_PARTY_NOTICES.md` と、配布物に含める複製（`docs/`・`manuscript/`）が一致していることを検証する。
 - `build_dist.sh`  

--- a/templates/style_guide.md
+++ b/templates/style_guide.md
@@ -72,6 +72,12 @@ chapter: "X-Y"
 
 - `chapter` は Part 内の通し番号（例：`1-2`）とし、ファイル名と整合させる。
 
+### 4.1 `docs/`（GitHub Pages/Jekyll）への同期
+
+- GitHub Pages 向けの `docs/part*/` と `docs/appendix/` は、原則 `manuscript/` から同期スクリプトで生成する。  
+  - 同期：`python3 scripts/sync_docs_from_manuscript.py`
+- 原稿（`manuscript/`）では、mdBook と Jekyll の両方で破綻しにくい Markdown を優先し、Jekyll 固有の記法（Liquid 等）を本文に混入させない。
+
 ## 5. 章構成の基本パターン
 
 原則として、1 ファイル（1 章）内は次の構成を基本とする。


### PR DESCRIPTION
## 背景

GitHub Pages の提供形態が `main:/docs`（Jekyll/legacy）に切り替わっているため、Actions の `pages` workflow が不要なデプロイを試行して失敗する状態になっていました。

## 変更点

- `.github/workflows/pages.yml`
  - Pages API の `build_type` を確認し、`legacy`（`/docs` ソース）の場合は Actions デプロイをスキップ
  - 将来 `workflow`（GitHub Actions デプロイ）へ切り替えた場合に備え `environment: github-pages` を付与
- 運用ドキュメント
  - `README.md` に `docs/` 同期手順（`python3 scripts/sync_docs_from_manuscript.py`）を明記
  - `CONTRIBUTING.md` / `scripts/README.md` / `templates/style_guide.md` に `docs/` 同期の前提を追記

## 動作確認

- `mdbook build`
- `bash scripts/check_canonical_files.sh`
- `python3 scripts/sync_docs_from_manuscript.py`（差分なし）
