### PR TITLE
CI: ensure docs/ is synced from manuscript

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -14,6 +14,17 @@ jobs:
       - name: Check canonical files
         run: bash scripts/check_canonical_files.sh
 
+      - name: Sync docs from manuscript
+        run: python3 scripts/sync_docs_from_manuscript.py
+
+      - name: Ensure docs are up to date
+        run: |
+          if ! git diff --exit-code -- docs; then
+            echo "ERROR: docs/ is out of sync with manuscript/. Run: python3 scripts/sync_docs_from_manuscript.py"
+            git diff --name-only -- docs
+            exit 1
+          fi
+
       - name: Install mdBook
         uses: peaceiris/actions-mdbook@v2
         with:


### PR DESCRIPTION
## 概要

GitHub Pages は `docs/`（Jekyll）をソースとしてビルドされるため、`manuscript/` 更新時に `docs/` の同期漏れがあると公開内容が更新されません。
本 PR では、CI（`book` workflow）で同期漏れを検知して失敗させるようにします。

## 変更点

- `.github/workflows/book.yml`
  - `python3 scripts/sync_docs_from_manuscript.py` を実行
  - 実行後に `docs/` の差分が残る場合は失敗（同期漏れとして通知）

## 使い方（開発側）

- 本文更新後に `python3 scripts/sync_docs_from_manuscript.py` を実行し、生成された `docs/` の差分もコミットしてください。
