### PR TITLE
Docs: improve appendix links on docs home

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -32,7 +32,9 @@ Pentest は攻撃と同質の行為を扱います。**許可された範囲内*
 
 - 用語に迷ったら: [用語集](appendix/glossary.md)
 - すぐ演習を動かしたい: [演習環境クイックスタート](appendix/exercises_quickstart.md)
-- 成果物の作り方: [テンプレート](appendix/templates.md)
+- 何を確認し、何を残すか: [演習タスクと成果物ガイド](appendix/exercises_tasks.md)
+- 記入の粒度を確認したい: [サンプル成果物（記入例）](appendix/samples.md)
+- モバイルの対象アプリを用意したい: [モバイル演習用アプリの準備ガイド](appendix/mobile_exercise_app_guide.md)
+- 成果物の作り方（フォーマット）: [テンプレート](appendix/templates.md)
 
 {% include page-navigation.html %}
-


### PR DESCRIPTION
## 概要

Jekyll 版トップページ（`docs/index.md`）の「付録（目的別）」導線を、追加済みの付録（演習タスク/サンプル成果物/モバイル準備ガイド）に合わせて更新します。

## 変更点

- 付録リンクを拡充（演習タスクと成果物ガイド、サンプル成果物、モバイル演習用アプリ準備ガイド）
