### PR TITLE
Docs: link mobile app guide from MobSF exercise

### DIFF
--- a/docs/part5_mobile/52_mobsf_static_analysis.md
+++ b/docs/part5_mobile/52_mobsf_static_analysis.md
@@ -10,7 +10,7 @@ MobSF（Mobile Security Framework）は、Android / iOS アプリケーション
 
 ## 本章のゴール
 
-- 前提：評価対象の APK / IPA を用意し、`exercises/mobsf/` で MobSF を起動できる検証環境が用意されている。
+- 前提：評価対象の APK / IPA を用意し（選定観点は付録『[モバイル演習用アプリの準備ガイド](../appendix/mobile_exercise_app_guide.md)』を参照）、`exercises/mobsf/` で MobSF を起動できる検証環境が用意されている。
 - 到達目標：MobSF のレポートから重点確認項目（マニフェスト、パーミッション、ハードコード、ストレージ利用）を抽出し、後続の手動解析・動的解析の優先度付けに利用できる。
 - 対応演習：`exercises/mobsf/` で MobSF を起動し、評価対象アプリを投入して、重要度の高い指摘（例：`debuggable`、クリアテキスト通信許可、ハードコード情報）を中心に確認結果を記録する。  
   起動手順は [付録「演習環境クイックスタート」](../appendix/exercises_quickstart.md) を参照し、記録フォーマットは [学習ログテンプレート（Burp Academy / 演習）](../appendix/templates_learning_log.md) を参照する。

--- a/exercises/mobsf/README.md
+++ b/exercises/mobsf/README.md
@@ -10,6 +10,7 @@ title: "MobSF 演習環境（exercises/mobsf）"
 
 - Docker Engine と `docker compose`（Compose v2）が利用可能であること。
 - 演習対象は **許可された検証用アプリ（演習用アプリ）** に限定すること。
+- 解析対象アプリ（APK / IPA）は別途用意する（選定観点は [付録：モバイル演習用アプリの準備ガイド](../../manuscript/appendix/mobile_exercise_app_guide.md) を参照）。
 
 ## 起動
 

--- a/manuscript/part5_mobile/52_mobsf_static_analysis.md
+++ b/manuscript/part5_mobile/52_mobsf_static_analysis.md
@@ -10,7 +10,7 @@ MobSF（Mobile Security Framework）は、Android / iOS アプリケーション
 
 ## 本章のゴール
 
-- 前提：評価対象の APK / IPA を用意し、`exercises/mobsf/` で MobSF を起動できる検証環境が用意されている。
+- 前提：評価対象の APK / IPA を用意し（選定観点は付録『[モバイル演習用アプリの準備ガイド](../appendix/mobile_exercise_app_guide.md)』を参照）、`exercises/mobsf/` で MobSF を起動できる検証環境が用意されている。
 - 到達目標：MobSF のレポートから重点確認項目（マニフェスト、パーミッション、ハードコード、ストレージ利用）を抽出し、後続の手動解析・動的解析の優先度付けに利用できる。
 - 対応演習：`exercises/mobsf/` で MobSF を起動し、評価対象アプリを投入して、重要度の高い指摘（例：`debuggable`、クリアテキスト通信許可、ハードコード情報）を中心に確認結果を記録する。  
   起動手順は [付録「演習環境クイックスタート」](../appendix/exercises_quickstart.md) を参照し、記録フォーマットは [学習ログテンプレート（Burp Academy / 演習）](../appendix/templates_learning_log.md) を参照する。


### PR DESCRIPTION
## 概要

Part 5（MobSF）で必須となる「解析対象アプリ（APK/IPA）の準備」で迷わないよう、本文と演習環境 README から付録ガイドへリンクします。

## 変更点

- `manuscript/part5_mobile/52_mobsf_static_analysis.md`：前提に「モバイル演習用アプリの準備ガイド」へのリンクを追加
- `exercises/mobsf/README.md`：対象アプリ準備ガイドへのリンクを追加
- `docs/part5_mobile/52_mobsf_static_analysis.md`：同期反映

## 関連

- Ref: #136
