### PR TITLE
Docs: link sample deliverables from exercise guide

### DIFF
--- a/docs/appendix/exercises_tasks.md
+++ b/docs/appendix/exercises_tasks.md
@@ -127,3 +127,4 @@
 
 - 対応章：Part 7（[総合演習（1週間カリキュラム）](../part7_final/70_overview.md)）
 - テンプレート：付録『[スコーピングシートテンプレート（Pentest）](templates_scoping_sheet.md)』、付録『[テスト計画書テンプレート（Pentest）](templates_test_plan_template.md)』、付録『[Pentest レポートテンプレート](templates_pentest_report.md)』
+- サンプル：付録『[サンプル成果物（記入例）](samples.md)』

--- a/docs/part7_final/70_overview.md
+++ b/docs/part7_final/70_overview.md
@@ -53,6 +53,7 @@ Part 7 では、本書で扱った Web / API / モバイル / クラウド / イ
 - [テスト計画書テンプレート（Pentest）](../appendix/templates_test_plan_template.md)
 - [学習ログテンプレート（Burp Academy / 演習）](../appendix/templates_learning_log.md)
 - [Pentest レポートテンプレート](../appendix/templates_pentest_report.md)
+- [サンプル成果物（記入例）](../appendix/samples.md)
 - [Web Pentest チェックリスト（原案）](../appendix/checklists_web.md)
 - [API Security チェックリスト（原案）](../appendix/checklists_api.md)
 - [OAuth2 / OIDC テスト項目表（原案）](../appendix/checklists_oauth_oidc.md)

--- a/manuscript/appendix/exercises_tasks.md
+++ b/manuscript/appendix/exercises_tasks.md
@@ -127,3 +127,4 @@
 
 - 対応章：Part 7（[総合演習（1週間カリキュラム）](../part7_final/70_overview.md)）
 - テンプレート：付録『[スコーピングシートテンプレート（Pentest）](templates_scoping_sheet.md)』、付録『[テスト計画書テンプレート（Pentest）](templates_test_plan_template.md)』、付録『[Pentest レポートテンプレート](templates_pentest_report.md)』
+- サンプル：付録『[サンプル成果物（記入例）](samples.md)』

--- a/manuscript/part7_final/70_overview.md
+++ b/manuscript/part7_final/70_overview.md
@@ -53,6 +53,7 @@ Part 7 では、本書で扱った Web / API / モバイル / クラウド / イ
 - [テスト計画書テンプレート（Pentest）](../appendix/templates_test_plan_template.md)
 - [学習ログテンプレート（Burp Academy / 演習）](../appendix/templates_learning_log.md)
 - [Pentest レポートテンプレート](../appendix/templates_pentest_report.md)
+- [サンプル成果物（記入例）](../appendix/samples.md)
 - [Web Pentest チェックリスト（原案）](../appendix/checklists_web.md)
 - [API Security チェックリスト（原案）](../appendix/checklists_api.md)
 - [OAuth2 / OIDC テスト項目表（原案）](../appendix/checklists_oauth_oidc.md)


### PR DESCRIPTION
## 概要

成果物作成の迷いを減らすため、演習タスクガイドと Part 7 概要から「サンプル成果物（記入例）」へ導線を追加します。

## 変更点

- `manuscript/appendix/exercises_tasks.md`：総合演習の参照にサンプル付録リンクを追加
- `manuscript/part7_final/70_overview.md`：関連資料にサンプル付録リンクを追加
- `docs/` 側は同期反映
