### PR TITLE
Docs: add appendix links to learning paths

### DIFF
--- a/roadmap/learning-paths.md
+++ b/roadmap/learning-paths.md
@@ -21,4 +21,8 @@
 ## 演習の進め方
 
 - 本書の演習は、原則としてローカルの演習環境（`exercises/`）または許可済み環境を対象とする。
+- 起動・停止手順は付録「[演習環境クイックスタート](../manuscript/appendix/exercises_quickstart.md)」を参照する。
+- 何を確認し、何を成果物として残すかは付録「[演習タスクと成果物ガイド](../manuscript/appendix/exercises_tasks.md)」を参照する。
+- 成果物の粒度（記入例）は付録「[サンプル成果物（記入例）](../manuscript/appendix/samples.md)」を参照する。
+- モバイル（Part 5）の対象アプリ選定は付録「[モバイル演習用アプリの準備ガイド](../manuscript/appendix/mobile_exercise_app_guide.md)」を参照する。
 - 手順の差分（OS/バージョン差など）が出た場合は、Issue として記録し、再現条件を明確化する。


### PR DESCRIPTION
## 概要

`roadmap/learning-paths.md` から、演習実施に必要な付録（クイックスタート/演習タスク/サンプル成果物/モバイル準備）へ直接リンクを追加し、学習導線を補強します。
