### PR TITLE
fix: Pagesのライセンスリンク修正

### DIFF
--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -116,7 +116,7 @@ appendices:
   - title: "付録：テンプレート"
     path: "/appendix/templates/"
   - title: "付録：ライセンス"
-    path: "/appendix/license/"
+    path: "/appendix/license.md"
   - title: "付録：Third-Party Notices"
     path: "/appendix/third_party_notices/"
 

--- a/docs/appendix/license.md
+++ b/docs/appendix/license.md
@@ -1,8 +1,3 @@
----
-title: "付録：ライセンス"
-permalink: /appendix/license/
----
-
 # ライセンス
 
 ## 基本ライセンス


### PR DESCRIPTION
GitHub Pages で `/appendix/license/` と `/LICENSE/` が 404 になるため、`.md` への直接リンクに変更しました。
