### PR TITLE
演習スクリプトを docker compose (Compose v2) 前提に更新

### DIFF
--- a/scripts/cleanup_exercises.sh
+++ b/scripts/cleanup_exercises.sh
@@ -25,7 +25,7 @@ Options:
   -h, --help   ヘルプを表示する
 
 Notes:
-  - 本スクリプトは Docker Compose（推奨）または podman-compose を前提とする。
+  - 本スクリプトは Docker Compose v2（`docker compose`、推奨）または podman-compose を前提とする。
 USAGE
 }
 
@@ -38,10 +38,6 @@ detect_compose() {
   if command -v docker >/dev/null 2>&1; then
     if docker compose version >/dev/null 2>&1; then
       compose_cmd=(docker compose)
-      return 0
-    fi
-    if command -v docker-compose >/dev/null 2>&1; then
-      compose_cmd=(docker-compose)
       return 0
     fi
   fi
@@ -85,7 +81,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 if ! detect_compose; then
-  err "Docker Compose または podman-compose が見つからない。Docker（推奨）または Podman をセットアップしてから再実行すること。"
+  err "Docker Compose v2（docker compose）または podman-compose が見つからない。Docker（推奨）または Podman をセットアップしてから再実行すること。"
   exit 1
 fi
 

--- a/scripts/setup_exercises.sh
+++ b/scripts/setup_exercises.sh
@@ -25,7 +25,7 @@ Options:
   -h, --help   ヘルプを表示する
 
 Notes:
-  - 本スクリプトは Docker Compose（推奨）または podman-compose を前提とする。
+  - 本スクリプトは Docker Compose v2（`docker compose`、推奨）または podman-compose を前提とする。
   - 演習環境は意図的に脆弱である。必ずローカル環境（または許可された検証環境）でのみ実行すること。
 USAGE
 }
@@ -39,10 +39,6 @@ detect_compose() {
   if command -v docker >/dev/null 2>&1; then
     if docker compose version >/dev/null 2>&1; then
       compose_cmd=(docker compose)
-      return 0
-    fi
-    if command -v docker-compose >/dev/null 2>&1; then
-      compose_cmd=(docker-compose)
       return 0
     fi
   fi
@@ -86,7 +82,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 if ! detect_compose; then
-  err "Docker Compose または podman-compose が見つからない。Docker（推奨）または Podman をセットアップしてから再実行すること。"
+  err "Docker Compose v2（docker compose）または podman-compose が見つからない。Docker（推奨）または Podman をセットアップしてから再実行すること。"
   exit 1
 fi
 


### PR DESCRIPTION
- `docker compose`（Compose v2）を優先する方針に合わせ、演習スクリプトの検出ロジックから Compose v1（`docker-compose`）の前提を削除しました。\n- Podman 環境では `podman-compose` を引き続き利用できます。\n