### PR TITLE
ci: actions/upload-pages-artifact を v4 に更新

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -110,7 +110,7 @@ jobs:
 
       - name: Upload Pages artifact
         if: steps.pages.outputs.enabled == 'true'
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: book
 


### PR DESCRIPTION
- `.github/workflows/pages.yml` の `actions/upload-pages-artifact@v3` を `@v4` に更新
- 変更範囲はPages artifact uploadの公式Action参照のみ

関連: https://github.com/itdojp/it-engineer-knowledge-architecture/issues/102