### PR TITLE
docs: add language specifier to README tree code fence

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Pentest は攻撃と同質の行為を扱うため、**許可された範囲内*
 
 ## リポジトリ構成
 
-```
+```text
 pentest-learning-book/
 ├── manuscript/         # 書籍本文（Markdown）
 │   ├── part0_intro/


### PR DESCRIPTION
## 概要
- `README.md` のリポジトリ構成ツリーコードフェンスに言語指定 `text` を追加しました。

## 背景
- `check-markdown-structure` で `missing_fence_language` が1件検出されていたためです。

## 変更ファイル
- `README.md`

## 検証
- `node book-formatter/scripts/check-markdown-structure.js . --fail-on error`
  - errors: 0
  - warnings: 0

## 関連
- itdojp/it-engineer-knowledge-architecture#102
