### PR TITLE
Fix navigation prev/next (dedupe + license permalink)

### DIFF
--- a/docs/appendix/license_page.md
+++ b/docs/appendix/license_page.md
@@ -1,3 +1,8 @@
+---
+title: "ライセンス"
+permalink: /appendix/license/
+---
+
 # ライセンス
 
 ## 基本ライセンス
@@ -106,3 +111,5 @@ URL: https://itdo.jp
 ---
 © 2025 株式会社アイティードゥ (ITDO Inc.)
 All Rights Reserved.
+
+

--- a/manuscript/appendix/license.md
+++ b/manuscript/appendix/license.md
@@ -1,8 +1,3 @@
----
-title: "ライセンス"
-permalink: /appendix/license/
----
-
 # ライセンス
 
 ## 基本ライセンス

--- a/manuscript/appendix/license_page.md
+++ b/manuscript/appendix/license_page.md
@@ -1,0 +1,7 @@
+---
+title: "ライセンス"
+permalink: /appendix/license/
+---
+
+{{#include license.md}}
+


### PR DESCRIPTION
Issue #110 の公開ページ検証で、pentest-learning-book の prev/next が期待順序と不一致になっていました。\n\n対応内容:\n- navigation.yml の introduction/chapter で重複していた /part0_intro/00_overview/ を重複しないよう整理\n- resources の外部 URL が prev/next 導線に混入していたため、ナビから除外（ライセンス/Third-Party Notices は付録側に集約）\n- docs/appendix/license.md に front matter + permalink を追加し、/appendix/license/ を HTML ページとして提供（nav も /appendix/license/ に更新）\n\n確認観点:\n- /part0_intro/00_overview/ の next が自己参照しない\n- /appendix/license/ が 200 で表示できる\n- Issue #110 の link checker（tmp_check_public_pages_links_issue110.py）で 28/28 になること