### PR TITLE
サイドバー目次の章リンクを復旧（Part構造navigation対応）

### DIFF
--- a/docs/_includes/sidebar-nav.html
+++ b/docs/_includes/sidebar-nav.html
@@ -31,8 +31,14 @@
                 <ul class="toc-list">
                     {% for item in navigation.introduction %}
                     {% assign item_url = item.path | default: item.url %}
+                    {% assign item_active = false %}
+                    {% if item_url and item_url != '' %}
+                      {% if page.url == item_url or page.url contains item_url %}
+                        {% assign item_active = true %}
+                      {% endif %}
+                    {% endif %}
                     <li class="toc-item">
-                        <a href="{{ item_url | relative_url }}" class="toc-link {% if page.url == item_url %}active{% endif %}" {% if page.url == item_url %}aria-current="page"{% endif %}>
+                        <a href="{{ item_url | relative_url }}" class="toc-link {% if item_active %}active{% endif %}" {% if item_active %}aria-current="page"{% endif %}>
                             {{ item.title }}
                         </a>
                     </li>
@@ -48,7 +54,7 @@
                     {% for chapter in navigation.chapters %}
                       {% if chapter.items %}
                         <li class="toc-item toc-chapter">
-                          <span class="toc-link">{{ chapter.part }}</span>
+                          <span class="toc-part-label">{{ chapter.part }}</span>
                         </li>
                         {% for item in chapter.items %}
                           {% assign item_url = item.path | default: item.url %}

--- a/docs/assets/css/main.css
+++ b/docs/assets/css/main.css
@@ -306,6 +306,14 @@ a:hover {
     font-weight: 500;
 }
 
+.toc-part-label {
+    display: block;
+    padding: 0.5rem 0.75rem;
+    color: var(--text-muted);
+    border-radius: 6px;
+    font-weight: 500;
+}
+
 .toc-chapter .toc-link {
     font-weight: 500;
 }
@@ -323,6 +331,11 @@ a:hover {
 }
 
 .toc-section .toc-link {
+    font-size: 0.875rem;
+    padding: 0.375rem 0.75rem;
+}
+
+.toc-section .toc-part-label {
     font-size: 0.875rem;
     padding: 0.375rem 0.75rem;
 }


### PR DESCRIPTION
## 背景
公開ページのサイドバー目次（本編）が `href=""` となり、主要章へ遷移できない状態でした。

原因は `docs/_data/navigation.yml` の `chapters` が「Part（part/items）構造」になっている一方で、テンプレートが `title/path` のフラット構造のみを想定していたためです。

## 対応
- `docs/_includes/sidebar-nav.html` の「本編」表示を、以下両方のスキーマに対応させました。
  - フラット: `[{title, path|url}]`
  - Part構造: `[{part, items:[{title, path|url}]}]`
- 併せて `path` が無い場合の `url` フォールバック、および active 判定（aria-current 含む）も同じURL基準で行うようにしました。

## 期待される効果
- Part配下の各章リンクが正しいURLになり、クリックで遷移できます。
