### PR TITLE
[codex] Clarify pentest README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Web・API・モバイル・クラウドの統合セキュリティ実践
 
 Pentest Handbook / ペネトレーションテスト学習書籍プロジェクト
 
-- オンライン版（GitHub Pages）: https://itdojp.github.io/pentest-learning-book/
+- オンライン版（GitHub Pages）: [実務で使えるペネトレーションテスト大全](https://itdojp.github.io/pentest-learning-book/)
 - 目次（リポジトリ内）: `manuscript/SUMMARY.md`
 - 推奨ルート: `roadmap/learning-paths.md`
 


### PR DESCRIPTION
## Summary
- convert the public README URL to a Markdown link

## Testing
- npx --yes markdownlint-cli --disable MD013 README.md
- git diff --check