### PR TITLE
Add pentest metadata consistency gate

### DIFF
--- a/.github/workflows/book-dist.yml
+++ b/.github/workflows/book-dist.yml
@@ -17,6 +17,9 @@ jobs:
       - name: Check canonical files
         run: bash scripts/check_canonical_files.sh
 
+      - name: Metadata consistency check
+        run: python3 scripts/check_metadata_consistency.py
+
       - name: Install mdBook
         uses: peaceiris/actions-mdbook@v2
         with:

--- a/.github/workflows/book-qa.yml
+++ b/.github/workflows/book-qa.yml
@@ -19,6 +19,9 @@ jobs:
       - name: Checkout book
         uses: actions/checkout@v6
 
+      - name: Metadata consistency check
+        run: python3 scripts/check_metadata_consistency.py
+
       - name: Checkout book-formatter (pinned)
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -28,6 +28,9 @@ jobs:
             exit 1
           fi
 
+      - name: Metadata consistency check
+        run: python3 scripts/check_metadata_consistency.py
+
       - name: Install mdBook
         uses: peaceiris/actions-mdbook@v2
         with:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -89,6 +89,10 @@ jobs:
         if: steps.pages.outputs.enabled == 'true'
         run: bash scripts/check_canonical_files.sh
 
+      - name: Metadata consistency check
+        if: steps.pages.outputs.enabled == 'true'
+        run: python3 scripts/check_metadata_consistency.py
+
       - name: Install mdBook
         if: steps.pages.outputs.enabled == 'true'
         uses: peaceiris/actions-mdbook@v2

--- a/README.md
+++ b/README.md
@@ -182,6 +182,20 @@ python3 scripts/sync_docs_from_manuscript.py
 
 原則として、書籍本文に対応する `docs/part*/` と `docs/appendix/` は同期スクリプトで生成する（手編集しない）。
 
+### ローカル品質ゲート
+
+公開メタデータとナビゲーションのずれを防ぐため、PR前に次のチェックを実行してください。
+
+```bash
+python3 scripts/check_metadata_consistency.py
+bash scripts/check_canonical_files.sh
+python3 scripts/sync_docs_from_manuscript.py
+git diff --exit-code -- docs
+mdbook build
+```
+
+`check_metadata_consistency.py` は `book-config.json`、`book.toml`、`docs/_config.yml`、`docs/index.md`、`docs/_data/navigation.yml`、`docs/SUMMARY.md`、必須公開アセットの整合を検証します。
+
 ---
 
 ## PDF/EPUB 生成（暫定）

--- a/book-config.json
+++ b/book-config.json
@@ -25,5 +25,6 @@
   "shared": {
     "version": "3.2.2",
     "lastSync": "2026-02-04T23:01:10.960Z"
-  }
+  },
+  "homepage": "https://itdojp.github.io/pentest-learning-book/"
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,8 @@
 layout: book
 title: "実務で使えるペネトレーションテスト大全"
 description: "Web・API・モバイル・クラウドを横断して、実務で再現可能なペネトレーションテストを学ぶ"
+author: "株式会社アイティードゥ"
+version: "0.1.0"
 permalink: /
 ---
 

--- a/scripts/check_metadata_consistency.py
+++ b/scripts/check_metadata_consistency.py
@@ -173,7 +173,9 @@ def docs_candidates_for_public_path(docs_root: Path, path_value: str, errors: li
     if path_value.startswith(("http://", "https://", "mailto:")):
         return []
     if "#" in path_value or "?" in path_value:
-        errors.append(f"{label} path is malformed: {path_value}")
+        errors.append(
+            f"{label} path must not contain fragment/query characters ('#' or '?'): {path_value}"
+        )
         return []
     if has_malformed_path_chars(path_value):
         errors.append(f"{label} path is malformed: {path_value!r}")

--- a/scripts/check_metadata_consistency.py
+++ b/scripts/check_metadata_consistency.py
@@ -133,10 +133,10 @@ def public_path_for_markdown(target: str) -> str:
 def check_relative_target(root: Path, target: str, label: str, errors: list[str]) -> Path | None:
     clean = target.split("#", 1)[0].split("?", 1)[0]
     if not clean:
-        errors.append(f"{label} target is malformed: {target!r}")
+        errors.append(f"{label} target is empty after removing fragment/query: {target!r}")
         return None
     if has_malformed_path_chars(clean):
-        errors.append(f"{label} target is malformed: {target!r}")
+        errors.append(f"{label} target contains invalid path characters: {target!r}")
         return None
     posix = PurePosixPath(clean)
     if posix.is_absolute() or ".." in posix.parts:

--- a/scripts/check_metadata_consistency.py
+++ b/scripts/check_metadata_consistency.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+"""Validate publication metadata and navigation consistency for this book.
+
+The repository intentionally avoids Node/npm project metadata, so this checker uses
+Python's standard library only.  It keeps the canonical `book-config.json` aligned
+with the mdBook, Jekyll, README, navigation, and generated docs tree that power the
+published book.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+import tomllib
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+REPO_SLUG = "itdojp/pentest-learning-book"
+PAGES_URL = "https://itdojp.github.io/pentest-learning-book/"
+PAGES_ORIGIN = "https://itdojp.github.io"
+BASEURL = "/pentest-learning-book"
+REQUIRED_ASSETS = (
+    "assets/css/main.css",
+    "assets/css/search.css",
+    "assets/css/syntax-highlighting.css",
+    "assets/js/theme.js",
+    "assets/js/search.js",
+    "assets/js/code-copy-lightweight.js",
+    "assets/js/safe-main.js",
+)
+
+
+def parse_scalar(value: str) -> str:
+    value = value.strip()
+    if (value.startswith('"') and value.endswith('"')) or (
+        value.startswith("'") and value.endswith("'")
+    ):
+        return value[1:-1]
+    return value
+
+
+def parse_simple_yaml(path: Path) -> dict[str, str]:
+    data: dict[str, str] = {}
+    if not path.exists():
+        return data
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        stripped = raw.strip()
+        if not stripped or stripped.startswith("#") or raw.startswith((" ", "-")):
+            continue
+        if ":" not in stripped:
+            continue
+        key, value = stripped.split(":", 1)
+        key = key.strip()
+        value = value.strip()
+        if value:
+            data[key] = parse_scalar(value)
+    return data
+
+
+def parse_front_matter(path: Path) -> dict[str, str]:
+    text = path.read_text(encoding="utf-8")
+    if not text.startswith("---\n"):
+        return {}
+    end = text.find("\n---\n", 4)
+    if end == -1:
+        return {}
+    front = text[4:end]
+    data: dict[str, str] = {}
+    for raw in front.splitlines():
+        stripped = raw.strip()
+        if not stripped or stripped.startswith("#") or ":" not in stripped:
+            continue
+        key, value = stripped.split(":", 1)
+        data[key.strip()] = parse_scalar(value)
+    return data
+
+
+def parse_navigation(path: Path) -> list[dict[str, Any]]:
+    entries: list[dict[str, Any]] = []
+    pending_title: tuple[str, int] | None = None
+    for lineno, raw in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        stripped = raw.strip()
+        title_match = re.match(r"-\s+title:\s*(.+)$", stripped)
+        if title_match:
+            pending_title = (parse_scalar(title_match.group(1)), lineno)
+            continue
+        path_match = re.match(r"path:\s*(.+)$", stripped)
+        if path_match and pending_title:
+            entries.append(
+                {
+                    "title": pending_title[0],
+                    "title_line": pending_title[1],
+                    "path": parse_scalar(path_match.group(1)),
+                    "path_line": lineno,
+                }
+            )
+            pending_title = None
+    return entries
+
+
+def parse_summary_links(path: Path) -> list[dict[str, Any]]:
+    entries: list[dict[str, Any]] = []
+    link_re = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+    for lineno, raw in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        for title, target in link_re.findall(raw):
+            target = target.strip()
+            if target.startswith(("http://", "https://", "mailto:", "#")):
+                continue
+            entries.append({"title": title.strip(), "target": target, "line": lineno})
+    return entries
+
+
+def normalize_repo_url(url: str) -> str:
+    return url.rstrip("/").removesuffix(".git")
+
+
+def public_path_for_markdown(target: str) -> str:
+    # Strip anchors/query because SUMMARY links may include them in the future.
+    clean = target.split("#", 1)[0].split("?", 1)[0]
+    posix = PurePosixPath(clean)
+    if posix.name == "index.md":
+        parent = str(posix.parent).strip(".")
+        return "/" if not parent else f"/{parent.strip('/')}/"
+    if clean.endswith(".md"):
+        clean = clean[:-3]
+    return f"/{clean.strip('/')}/"
+
+
+def check_relative_target(root: Path, target: str, label: str, errors: list[str]) -> Path | None:
+    clean = target.split("#", 1)[0].split("?", 1)[0]
+    posix = PurePosixPath(clean)
+    if posix.is_absolute() or ".." in posix.parts:
+        errors.append(f"{label} must be a relative in-tree path: {target}")
+        return None
+    candidate = root / Path(*posix.parts)
+    try:
+        resolved = candidate.resolve(strict=True)
+        resolved.relative_to(root.resolve())
+    except FileNotFoundError:
+        errors.append(f"{label} target does not exist: {target}")
+        return None
+    except ValueError:
+        errors.append(f"{label} target escapes repository tree: {target}")
+        return None
+    if not resolved.is_file() or resolved.stat().st_size == 0:
+        errors.append(f"{label} target is not a non-empty file: {target}")
+        return None
+    return resolved
+
+
+def docs_candidates_for_public_path(docs_root: Path, path_value: str, errors: list[str], label: str) -> list[Path]:
+    if not isinstance(path_value, str) or not path_value.strip():
+        errors.append(f"{label} path is missing")
+        return []
+    path_value = path_value.strip()
+    if path_value.startswith(("http://", "https://", "mailto:")):
+        return []
+    if not path_value.startswith("/"):
+        errors.append(f"{label} path must start with '/': {path_value}")
+        return []
+    parts = PurePosixPath(path_value.lstrip("/")).parts
+    if ".." in parts:
+        errors.append(f"{label} path must not contain '..': {path_value}")
+        return []
+    if path_value == "/":
+        return [docs_root / "index.md"]
+    rel = path_value.lstrip("/")
+    lower = rel.lower()
+    if lower.endswith(".md"):
+        return [docs_root / rel]
+    if lower.endswith((".html", ".htm", ".pdf", ".txt")):
+        return [docs_root / rel]
+    rel = rel.rstrip("/")
+    return [docs_root / f"{rel}.md", docs_root / rel / "index.md"]
+
+
+def existing_docs_candidate(candidates: list[Path], docs_root: Path, label: str, errors: list[str]) -> Path | None:
+    for candidate in candidates:
+        try:
+            resolved = candidate.resolve(strict=True)
+            resolved.relative_to(docs_root.resolve())
+        except FileNotFoundError:
+            continue
+        except ValueError:
+            errors.append(f"{label} target escapes docs tree: {candidate}")
+            return None
+        if resolved.is_file() and resolved.stat().st_size > 0:
+            return resolved
+    if candidates:
+        pretty = ", ".join(str(c.relative_to(docs_root.parent)) for c in candidates)
+        errors.append(f"{label} target does not exist in docs: {pretty}")
+    return None
+
+
+def expect_equal(errors: list[str], label: str, actual: Any, expected: Any) -> None:
+    if actual != expected:
+        errors.append(f"{label} mismatch: expected {expected!r}, got {actual!r}")
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[1]
+    docs_root = repo_root / "docs"
+    errors: list[str] = []
+
+    config = json.loads((repo_root / "book-config.json").read_text(encoding="utf-8"))
+    jekyll = parse_simple_yaml(docs_root / "_config.yml")
+    index_front = parse_front_matter(docs_root / "index.md")
+    nav_entries = parse_navigation(docs_root / "_data" / "navigation.yml")
+    summary_entries = parse_summary_links(docs_root / "SUMMARY.md")
+    manuscript_summary_entries = parse_summary_links(repo_root / "manuscript" / "SUMMARY.md")
+    readme = (repo_root / "README.md").read_text(encoding="utf-8")
+    book_toml = tomllib.loads((repo_root / "book.toml").read_text(encoding="utf-8"))
+
+    title = config.get("title")
+    description = config.get("description")
+    author = config.get("author")
+    version = config.get("version")
+    language = config.get("language")
+    repository = config.get("repository") or {}
+    repo_url = repository.get("url") if isinstance(repository, dict) else None
+
+    expect_equal(errors, "book-config.repository.url", normalize_repo_url(str(repo_url or "")), f"https://github.com/{REPO_SLUG}")
+    expect_equal(errors, "book-config.repository.branch", repository.get("branch") if isinstance(repository, dict) else None, "main")
+    expect_equal(errors, "book-config.homepage", config.get("homepage"), PAGES_URL)
+
+    expect_equal(errors, "book.toml book.title", (book_toml.get("book") or {}).get("title"), title)
+    expect_equal(errors, "book.toml book.language", (book_toml.get("book") or {}).get("language"), language)
+
+    for key, expected in {
+        "title": title,
+        "description": description,
+        "author": author,
+        "version": version,
+        "lang": language,
+        "url": PAGES_ORIGIN,
+        "baseurl": BASEURL,
+        "repository": REPO_SLUG,
+    }.items():
+        expect_equal(errors, f"docs/_config.yml {key}", jekyll.get(key), expected)
+
+    for key, expected in {
+        "title": title,
+        "description": description,
+        "author": author,
+        "version": version,
+        "permalink": "/",
+    }.items():
+        expect_equal(errors, f"docs/index.md front matter {key}", index_front.get(key), expected)
+
+    if str(title) not in readme:
+        errors.append("README.md must include the canonical book title")
+    if PAGES_URL not in readme:
+        errors.append(f"README.md must include the canonical Pages URL: {PAGES_URL}")
+
+    if not nav_entries:
+        errors.append("docs/_data/navigation.yml does not contain any title/path entries")
+
+    seen_nav_paths: dict[str, int] = {}
+    for entry in nav_entries:
+        path_value = entry["path"]
+        if path_value in seen_nav_paths:
+            errors.append(
+                f"duplicated navigation path {path_value!r} at lines {seen_nav_paths[path_value]} and {entry['path_line']}"
+            )
+        seen_nav_paths[path_value] = entry["path_line"]
+        candidates = docs_candidates_for_public_path(docs_root, path_value, errors, f"navigation line {entry['path_line']}")
+        existing_docs_candidate(candidates, docs_root, f"navigation line {entry['path_line']}", errors)
+
+    seen_summary_targets: dict[str, int] = {}
+    summary_public_paths: set[str] = set()
+    for entry in summary_entries:
+        target = entry["target"]
+        if target in seen_summary_targets:
+            errors.append(
+                f"duplicated docs/SUMMARY.md target {target!r} at lines {seen_summary_targets[target]} and {entry['line']}"
+            )
+        seen_summary_targets[target] = entry["line"]
+        check_relative_target(docs_root, target, f"docs/SUMMARY.md line {entry['line']}", errors)
+        summary_public_paths.add(public_path_for_markdown(target))
+
+    manuscript_targets = {entry["target"] for entry in manuscript_summary_entries}
+    docs_targets = {entry["target"] for entry in summary_entries}
+    missing_from_docs = sorted(manuscript_targets - docs_targets)
+    missing_from_manuscript = sorted(docs_targets - manuscript_targets)
+    if missing_from_docs:
+        errors.append("docs/SUMMARY.md is missing manuscript entries: " + ", ".join(missing_from_docs))
+    if missing_from_manuscript:
+        errors.append("docs/SUMMARY.md has entries not in manuscript/SUMMARY.md: " + ", ".join(missing_from_manuscript))
+
+    for target in manuscript_targets:
+        check_relative_target(repo_root / "manuscript", target, f"manuscript/SUMMARY.md target {target}", errors)
+
+    for entry in nav_entries:
+        path_value = entry["path"]
+        if path_value == "/":
+            continue
+        if path_value not in summary_public_paths:
+            errors.append(
+                f"navigation path {path_value!r} is not represented by docs/SUMMARY.md (line {entry['path_line']})"
+            )
+
+    for asset in REQUIRED_ASSETS:
+        asset_path = docs_root / asset
+        try:
+            resolved = asset_path.resolve(strict=True)
+            resolved.relative_to(docs_root.resolve())
+        except FileNotFoundError:
+            errors.append(f"required public asset is missing: docs/{asset}")
+            continue
+        except ValueError:
+            errors.append(f"required public asset escapes docs tree: docs/{asset}")
+            continue
+        if not resolved.is_file() or resolved.stat().st_size == 0:
+            errors.append(f"required public asset is not a non-empty file: docs/{asset}")
+
+    if errors:
+        print("Metadata consistency check failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+
+    print(
+        "OK: metadata consistency check passed "
+        f"({len(nav_entries)} navigation paths, {len(summary_entries)} summary links, {len(REQUIRED_ASSETS)} assets)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_metadata_consistency.py
+++ b/scripts/check_metadata_consistency.py
@@ -34,6 +34,10 @@ def has_malformed_path_chars(value: str) -> bool:
     return any(ch in value for ch in ("\x00", "\r", "\n", "\\"))
 
 
+def strip_fragment_and_query(value: str) -> str:
+    return value.split("#", 1)[0].split("?", 1)[0]
+
+
 def parse_scalar(value: str) -> str:
     value = value.strip()
     if (value.startswith('"') and value.endswith('"')) or (
@@ -120,7 +124,7 @@ def normalize_repo_url(url: str) -> str:
 
 def public_path_for_markdown(target: str) -> str:
     # Strip anchors/query because SUMMARY links may include them in the future.
-    clean = target.split("#", 1)[0].split("?", 1)[0]
+    clean = strip_fragment_and_query(target)
     posix = PurePosixPath(clean)
     if posix.name == "index.md":
         parent = str(posix.parent).strip(".")
@@ -131,7 +135,7 @@ def public_path_for_markdown(target: str) -> str:
 
 
 def check_relative_target(root: Path, target: str, label: str, errors: list[str]) -> Path | None:
-    clean = target.split("#", 1)[0].split("?", 1)[0]
+    clean = strip_fragment_and_query(target)
     if not clean:
         errors.append(f"{label} target is empty after removing fragment/query: {target!r}")
         return None
@@ -172,11 +176,13 @@ def docs_candidates_for_public_path(docs_root: Path, path_value: str, errors: li
     path_value = path_value.strip()
     if path_value.startswith(("http://", "https://", "mailto:")):
         return []
-    if "#" in path_value or "?" in path_value:
+    clean = strip_fragment_and_query(path_value)
+    if clean != path_value:
         errors.append(
             f"{label} path must not contain fragment/query characters ('#' or '?'): {path_value}"
         )
         return []
+    path_value = clean
     if has_malformed_path_chars(path_value):
         errors.append(f"{label} path is malformed: {path_value!r}")
         return []

--- a/scripts/check_metadata_consistency.py
+++ b/scripts/check_metadata_consistency.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import json
 import re
 import sys
-import tomllib
 from pathlib import Path, PurePosixPath
 from typing import Any
 
@@ -84,26 +83,71 @@ def parse_front_matter(path: Path) -> dict[str, str]:
 
 
 def parse_navigation(path: Path) -> list[dict[str, Any]]:
+    """Extract navigation entries from the project YAML shape.
+
+    This intentionally avoids a PyYAML dependency, but it does not assume field
+    order within a list item: both `- title: ...` / `path: ...` and
+    `- path: ...` / `title: ...` are accepted.
+    """
     entries: list[dict[str, Any]] = []
-    pending_title: tuple[str, int] | None = None
-    for lineno, raw in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
-        stripped = raw.strip()
-        title_match = re.match(r"-\s+title:\s*(.+)$", stripped)
-        if title_match:
-            pending_title = (parse_scalar(title_match.group(1)), lineno)
-            continue
-        path_match = re.match(r"path:\s*(.+)$", stripped)
-        if path_match and pending_title:
+    current: dict[str, Any] | None = None
+
+    def flush() -> None:
+        nonlocal current
+        if not current:
+            return
+        fields = current.get("fields", {})
+        lines = current.get("lines", {})
+        if "title" in fields and "path" in fields:
             entries.append(
                 {
-                    "title": pending_title[0],
-                    "title_line": pending_title[1],
-                    "path": parse_scalar(path_match.group(1)),
-                    "path_line": lineno,
+                    "title": fields["title"],
+                    "title_line": lines["title"],
+                    "path": fields["path"],
+                    "path_line": lines["path"],
                 }
             )
-            pending_title = None
+        current = None
+
+    for lineno, raw in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        if not raw.strip() or raw.lstrip().startswith("#"):
+            continue
+        indent = len(raw) - len(raw.lstrip(" "))
+        stripped = raw.strip()
+        item_match = re.match(r"-\s+(title|path):\s*(.+)$", stripped)
+        if item_match:
+            flush()
+            key, value = item_match.group(1), parse_scalar(item_match.group(2))
+            current = {"indent": indent, "fields": {key: value}, "lines": {key: lineno}}
+            continue
+        if stripped.startswith("- "):
+            flush()
+            continue
+        field_match = re.match(r"(title|path):\s*(.+)$", stripped)
+        if field_match and current is not None and indent > current["indent"]:
+            key, value = field_match.group(1), parse_scalar(field_match.group(2))
+            current["fields"][key] = value
+            current["lines"][key] = lineno
+            continue
+    flush()
     return entries
+
+
+def parse_book_toml(path: Path) -> dict[str, dict[str, str]]:
+    data: dict[str, dict[str, str]] = {}
+    section: str | None = None
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        stripped = raw.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if stripped.startswith("[") and stripped.endswith("]"):
+            section = stripped.strip("[]")
+            data.setdefault(section, {})
+            continue
+        if section and "=" in stripped:
+            key, value = stripped.split("=", 1)
+            data.setdefault(section, {})[key.strip()] = parse_scalar(value)
+    return data
 
 
 def parse_summary_links(path: Path) -> list[dict[str, Any]]:
@@ -243,7 +287,7 @@ def main() -> int:
     summary_entries = parse_summary_links(docs_root / "SUMMARY.md")
     manuscript_summary_entries = parse_summary_links(repo_root / "manuscript" / "SUMMARY.md")
     readme = (repo_root / "README.md").read_text(encoding="utf-8")
-    book_toml = tomllib.loads((repo_root / "book.toml").read_text(encoding="utf-8"))
+    book_toml = parse_book_toml(repo_root / "book.toml")
 
     title = config.get("title")
     description = config.get("description")

--- a/scripts/check_metadata_consistency.py
+++ b/scripts/check_metadata_consistency.py
@@ -30,6 +30,10 @@ REQUIRED_ASSETS = (
 )
 
 
+def has_malformed_path_chars(value: str) -> bool:
+    return any(ch in value for ch in ("\x00", "\r", "\n", "\\"))
+
+
 def parse_scalar(value: str) -> str:
     value = value.strip()
     if (value.startswith('"') and value.endswith('"')) or (
@@ -128,11 +132,21 @@ def public_path_for_markdown(target: str) -> str:
 
 def check_relative_target(root: Path, target: str, label: str, errors: list[str]) -> Path | None:
     clean = target.split("#", 1)[0].split("?", 1)[0]
+    if not clean:
+        errors.append(f"{label} target is malformed: {target!r}")
+        return None
+    if has_malformed_path_chars(clean):
+        errors.append(f"{label} target is malformed: {target!r}")
+        return None
     posix = PurePosixPath(clean)
     if posix.is_absolute() or ".." in posix.parts:
         errors.append(f"{label} must be a relative in-tree path: {target}")
         return None
-    candidate = root / Path(*posix.parts)
+    try:
+        candidate = root / Path(*posix.parts)
+    except ValueError:
+        errors.append(f"{label} target is malformed: {target!r}")
+        return None
     try:
         resolved = candidate.resolve(strict=True)
         resolved.relative_to(root.resolve())
@@ -141,6 +155,9 @@ def check_relative_target(root: Path, target: str, label: str, errors: list[str]
         return None
     except ValueError:
         errors.append(f"{label} target escapes repository tree: {target}")
+        return None
+    except OSError:
+        errors.append(f"{label} target is malformed: {target!r}")
         return None
     if not resolved.is_file() or resolved.stat().st_size == 0:
         errors.append(f"{label} target is not a non-empty file: {target}")
@@ -154,6 +171,12 @@ def docs_candidates_for_public_path(docs_root: Path, path_value: str, errors: li
         return []
     path_value = path_value.strip()
     if path_value.startswith(("http://", "https://", "mailto:")):
+        return []
+    if "#" in path_value or "?" in path_value:
+        errors.append(f"{label} path is malformed: {path_value}")
+        return []
+    if has_malformed_path_chars(path_value):
+        errors.append(f"{label} path is malformed: {path_value!r}")
         return []
     if not path_value.startswith("/"):
         errors.append(f"{label} path must start with '/': {path_value}")
@@ -183,6 +206,9 @@ def existing_docs_candidate(candidates: list[Path], docs_root: Path, label: str,
             continue
         except ValueError:
             errors.append(f"{label} target escapes docs tree: {candidate}")
+            return None
+        except OSError:
+            errors.append(f"{label} target is malformed: {candidate}")
             return None
         if resolved.is_file() and resolved.stat().st_size > 0:
             return resolved


### PR DESCRIPTION
## Summary
- Add a standard-library Python metadata consistency checker for `book-config.json`, `book.toml`, Jekyll metadata, top-page front matter, navigation, docs/manuscript summaries, and required public assets.
- Add canonical Pages `homepage` metadata and explicit top-page author/version front matter.
- Run the metadata checker in Book QA, mdBook build, Pages deploy, and distribution workflows.
- Document the local quality gate in README.

## Validation
- `python3 scripts/check_metadata_consistency.py`
- `bash scripts/check_canonical_files.sh`
- `python3 scripts/sync_docs_from_manuscript.py` (confirmed only the intentional `docs/index.md` metadata change is present in the working diff)
- `mdbook build`
- `jekyll build --source docs --destination .codex-local/tmp/pentest-quality-site`
- Built-site smoke for `/`, `/part6_cloud/63_cloud_security_tools/`, and `/appendix/checklists/`
- CI-pinned book-formatter checks: Unicode, textlint/PRH, internal links, layout risk, markdown structure
- Metadata fixtures for homepage drift, missing navigation target, summary traversal, and symlink escape
- `git diff --check`

## Notes
- No open issues or PRs were found in this repository before this slice.
- This repository does not currently have npm package metadata; no npm audit was applicable for this slice.