### PR TITLE
chore: consolidate local quality gate

### DIFF
--- a/.github/workflows/book-dist.yml
+++ b/.github/workflows/book-dist.yml
@@ -14,11 +14,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Check canonical files
-        run: bash scripts/check_canonical_files.sh
-
-      - name: Metadata consistency check
-        run: python3 scripts/check_metadata_consistency.py
+      - name: Local docs consistency gate
+        run: bash scripts/check_local_quality.sh
 
       - name: Install mdBook
         uses: peaceiris/actions-mdbook@v2

--- a/.github/workflows/book-qa.yml
+++ b/.github/workflows/book-qa.yml
@@ -19,8 +19,8 @@ jobs:
       - name: Checkout book
         uses: actions/checkout@v6
 
-      - name: Metadata consistency check
-        run: python3 scripts/check_metadata_consistency.py
+      - name: Local docs consistency gate
+        run: bash scripts/check_local_quality.sh
 
       - name: Checkout book-formatter (pinned)
         uses: actions/checkout@v6

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -14,22 +14,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Check canonical files
-        run: bash scripts/check_canonical_files.sh
-
-      - name: Sync docs from manuscript
-        run: python3 scripts/sync_docs_from_manuscript.py
-
-      - name: Ensure docs are up to date
-        run: |
-          if ! git diff --exit-code -- docs; then
-            echo "ERROR: docs/ is out of sync with manuscript/. Run: python3 scripts/sync_docs_from_manuscript.py"
-            git diff --name-only -- docs
-            exit 1
-          fi
-
-      - name: Metadata consistency check
-        run: python3 scripts/check_metadata_consistency.py
+      - name: Local docs consistency gate
+        run: bash scripts/check_local_quality.sh
 
       - name: Install mdBook
         uses: peaceiris/actions-mdbook@v2

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -85,13 +85,9 @@ jobs:
 
           echo "enabled=true" >> "$GITHUB_OUTPUT"
 
-      - name: Check canonical files
+      - name: Local docs consistency gate
         if: steps.pages.outputs.enabled == 'true'
-        run: bash scripts/check_canonical_files.sh
-
-      - name: Metadata consistency check
-        if: steps.pages.outputs.enabled == 'true'
-        run: python3 scripts/check_metadata_consistency.py
+        run: bash scripts/check_local_quality.sh
 
       - name: Install mdBook
         if: steps.pages.outputs.enabled == 'true'

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ book/
 dist/
 
 # Jekyll build output (local)
+_site/
 docs/_site/
 docs/.jekyll-cache/
 docs/.sass-cache/

--- a/README.md
+++ b/README.md
@@ -187,14 +187,11 @@ python3 scripts/sync_docs_from_manuscript.py
 公開メタデータとナビゲーションのずれを防ぐため、PR前に次のチェックを実行してください。
 
 ```bash
-python3 scripts/check_metadata_consistency.py
-bash scripts/check_canonical_files.sh
-python3 scripts/sync_docs_from_manuscript.py
-git diff --exit-code -- docs
+bash scripts/check_local_quality.sh
 mdbook build
 ```
 
-`check_metadata_consistency.py` は `book-config.json`、`book.toml`、`docs/_config.yml`、`docs/index.md`、`docs/_data/navigation.yml`、`docs/SUMMARY.md`、必須公開アセットの整合を検証します。
+`check_local_quality.sh` は canonical file、`manuscript/` → `docs/` 同期差分、`book-config.json`、`book.toml`、`docs/_config.yml`、`docs/index.md`、`docs/_data/navigation.yml`、`docs/SUMMARY.md`、必須公開アセットの整合を検証します。
 
 ---
 

--- a/scripts/check_local_quality.sh
+++ b/scripts/check_local_quality.sh
@@ -7,6 +7,11 @@ cd "$root_dir"
 bash scripts/check_canonical_files.sh
 python3 scripts/sync_docs_from_manuscript.py
 
+if ! git diff --check -- docs; then
+  echo "ERROR: docs/ has whitespace errors after manuscript sync." >&2
+  exit 1
+fi
+
 if ! git diff --exit-code -- docs; then
   echo "ERROR: docs/ is out of sync with manuscript/. Run: python3 scripts/sync_docs_from_manuscript.py" >&2
   git diff --name-only -- docs >&2

--- a/scripts/check_local_quality.sh
+++ b/scripts/check_local_quality.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$root_dir"
+
+bash scripts/check_canonical_files.sh
+python3 scripts/sync_docs_from_manuscript.py
+
+if ! git diff --exit-code -- docs; then
+  echo "ERROR: docs/ is out of sync with manuscript/. Run: python3 scripts/sync_docs_from_manuscript.py" >&2
+  git diff --name-only -- docs >&2
+  exit 1
+fi
+
+python3 scripts/check_metadata_consistency.py

--- a/scripts/check_local_quality.sh
+++ b/scripts/check_local_quality.sh
@@ -13,4 +13,11 @@ if ! git diff --exit-code -- docs; then
   exit 1
 fi
 
+docs_status="$(git status --porcelain -- docs)"
+if [[ -n "${docs_status}" ]]; then
+  echo "ERROR: docs/ has untracked or modified files after manuscript sync. Run: python3 scripts/sync_docs_from_manuscript.py and commit the docs/ mirror." >&2
+  printf '%s\n' "${docs_status}" >&2
+  exit 1
+fi
+
 python3 scripts/check_metadata_consistency.py

--- a/scripts/check_metadata_consistency.py
+++ b/scripts/check_metadata_consistency.py
@@ -275,12 +275,27 @@ def expect_equal(errors: list[str], label: str, actual: Any, expected: Any) -> N
         errors.append(f"{label} mismatch: expected {expected!r}, got {actual!r}")
 
 
+def read_json(path: Path, errors: list[str], label: str) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        errors.append(f"{label} must be readable JSON: {exc}")
+        return {}
+    except json.JSONDecodeError as exc:
+        errors.append(f"{label} must be readable JSON: {exc}")
+        return {}
+    if not isinstance(data, dict):
+        errors.append(f"{label} must contain a JSON object")
+        return {}
+    return data
+
+
 def main() -> int:
     repo_root = Path(__file__).resolve().parents[1]
     docs_root = repo_root / "docs"
     errors: list[str] = []
 
-    config = json.loads((repo_root / "book-config.json").read_text(encoding="utf-8"))
+    config = read_json(repo_root / "book-config.json", errors, "book-config.json")
     jekyll = parse_simple_yaml(docs_root / "_config.yml")
     index_front = parse_front_matter(docs_root / "index.md")
     nav_entries = parse_navigation(docs_root / "_data" / "navigation.yml")

--- a/scripts/check_metadata_consistency.py
+++ b/scripts/check_metadata_consistency.py
@@ -275,18 +275,18 @@ def expect_equal(errors: list[str], label: str, actual: Any, expected: Any) -> N
         errors.append(f"{label} mismatch: expected {expected!r}, got {actual!r}")
 
 
-def read_json(path: Path, errors: list[str], label: str) -> dict[str, Any]:
+def read_json(path: Path, errors: list[str], label: str) -> dict[str, Any] | None:
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
     except OSError as exc:
         errors.append(f"{label} must be readable JSON: {exc}")
-        return {}
+        return None
     except json.JSONDecodeError as exc:
         errors.append(f"{label} must be readable JSON: {exc}")
-        return {}
+        return None
     if not isinstance(data, dict):
         errors.append(f"{label} must contain a JSON object")
-        return {}
+        return None
     return data
 
 
@@ -303,6 +303,12 @@ def main() -> int:
     manuscript_summary_entries = parse_summary_links(repo_root / "manuscript" / "SUMMARY.md")
     readme = (repo_root / "README.md").read_text(encoding="utf-8")
     book_toml = parse_book_toml(repo_root / "book.toml")
+
+    if config is None:
+        print("Metadata consistency check failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
 
     title = config.get("title")
     description = config.get("description")


### PR DESCRIPTION
## Summary
- add `scripts/check_local_quality.sh` to run canonical-file, docs sync, clean-diff, and metadata consistency checks from one local gate
- reuse the same docs consistency gate in book, pages, dist, and Book QA workflows
- make malformed/missing `book-config.json` produce an actionable metadata validation error
- ignore root `_site/` from local Jekyll builds

## Verification
- `bash scripts/check_local_quality.sh`
- missing `book-config.json` fixture fails with an actionable metadata error
- `mdbook build`
- mdBook built-site smoke: top, part0 overview, part2 overview, glossary
- `jekyll build --source docs --destination _site`
- Jekyll built-site smoke: top, part0 overview, part2 overview, glossary
- workflow YAML parse for `.github/workflows/*.yml`
- pinned `itdojp/book-formatter@da2a49e7d2dcd9e1fa885e910c458130fe8d73a4` unicode/textlint/link/layout/structure checks (`--fail-on error` where applicable)
- `git diff --check`