### PR TITLE
Fix mobile sidebar closed state

### DIFF
--- a/docs/assets/css/mobile-responsive.css
+++ b/docs/assets/css/mobile-responsive.css
@@ -53,8 +53,21 @@ html {
     background: var(--bg-primary);
     border-right: 1px solid var(--border-color);
     box-shadow: 2px 0 8px rgba(0, 0, 0, 0.15);
-    z-index: 1000;
-    transform: translateX(-100%);
+    /*
+     * Keep the mobile drawer above the backdrop (`.book-sidebar-overlay` is
+     * 950) but below the fixed header (`.book-header` is 1000). This also
+     * needs to stay important so the later desktop `.book-sidebar` z-index in
+     * main.css cannot drop the mobile drawer behind the overlay.
+     */
+    z-index: 999 !important;
+    /*
+     * main.css imports this file before declaring the default desktop sidebar
+     * transform. Keep the closed drawer state important so the later desktop
+     * `transform: translateX(0)` rule cannot leave the TOC covering content
+     * on mobile and tablet widths. The checked/open rule below is more
+     * specific and also important, so the menu button still opens it.
+     */
+    transform: translateX(-100%) !important;
     transition: transform 0.3s ease;
   }
 

--- a/docs/assets/css/mobile-responsive.css
+++ b/docs/assets/css/mobile-responsive.css
@@ -68,12 +68,17 @@ html {
      * specific and also important, so the menu button still opens it.
      */
     transform: translateX(-100%) !important;
-    transition: transform 0.3s ease;
+    visibility: hidden;
+    transition:
+      transform 0.3s ease,
+      visibility 0s linear 0.3s;
   }
 
   /* Show sidebar when toggled */
   .sidebar-toggle-checkbox:checked ~ .book-layout .book-sidebar {
     transform: translateX(0) !important;
+    visibility: visible;
+    transition: transform 0.3s ease;
   }
   
   /* Ensure sidebar content is interactive */

--- a/scripts/check_local_quality.sh
+++ b/scripts/check_local_quality.sh
@@ -7,20 +7,36 @@ cd "$root_dir"
 bash scripts/check_canonical_files.sh
 python3 scripts/sync_docs_from_manuscript.py
 
-if ! git diff --check -- docs; then
-  echo "ERROR: docs/ has whitespace errors after manuscript sync." >&2
+# sync_docs_from_manuscript.py owns only the manuscript-derived markdown tree.
+# Static Pages assets under docs/assets are edited directly, so they must not be
+# treated as manuscript sync drift.
+synced_docs_paths=(
+  docs/part0_intro
+  docs/part1_basics
+  docs/part2_web
+  docs/part3_burp
+  docs/part4_api
+  docs/part5_mobile
+  docs/part6_cloud
+  docs/part7_final
+  docs/appendix
+  docs/SUMMARY.md
+)
+
+if ! git diff --check -- "${synced_docs_paths[@]}"; then
+  echo "ERROR: manuscript-synced docs have whitespace errors after sync." >&2
   exit 1
 fi
 
-if ! git diff --exit-code -- docs; then
-  echo "ERROR: docs/ is out of sync with manuscript/. Run: python3 scripts/sync_docs_from_manuscript.py" >&2
-  git diff --name-only -- docs >&2
+if ! git diff --exit-code -- "${synced_docs_paths[@]}"; then
+  echo "ERROR: manuscript-synced docs are out of sync. Run: python3 scripts/sync_docs_from_manuscript.py" >&2
+  git diff --name-only -- "${synced_docs_paths[@]}" >&2
   exit 1
 fi
 
-docs_status="$(git status --porcelain -- docs)"
+docs_status="$(git status --porcelain -- "${synced_docs_paths[@]}")"
 if [[ -n "${docs_status}" ]]; then
-  echo "ERROR: docs/ has untracked or modified files after manuscript sync. Run: python3 scripts/sync_docs_from_manuscript.py and commit the docs/ mirror." >&2
+  echo "ERROR: manuscript-synced docs have untracked or modified files after sync. Run: python3 scripts/sync_docs_from_manuscript.py and commit the docs/ mirror." >&2
   printf '%s\n' "${docs_status}" >&2
   exit 1
 fi

--- a/scripts/check_local_quality.sh
+++ b/scripts/check_local_quality.sh
@@ -7,20 +7,11 @@ cd "$root_dir"
 bash scripts/check_canonical_files.sh
 python3 scripts/sync_docs_from_manuscript.py
 
-# sync_docs_from_manuscript.py owns only the manuscript-derived markdown tree.
-# Static Pages assets under docs/assets are edited directly, so they must not be
-# treated as manuscript sync drift.
+# docs/assets contains directly maintained Pages assets and should be excluded
+# from manuscript drift checks.
 synced_docs_paths=(
-  docs/part0_intro
-  docs/part1_basics
-  docs/part2_web
-  docs/part3_burp
-  docs/part4_api
-  docs/part5_mobile
-  docs/part6_cloud
-  docs/part7_final
-  docs/appendix
-  docs/SUMMARY.md
+  docs
+  ":(exclude)docs/assets/**"
 )
 
 if ! git diff --check -- "${synced_docs_paths[@]}"; then


### PR DESCRIPTION
## Summary
- Keep the mobile/tablet sidebar closed state off-canvas with an important transform so the later desktop `.book-sidebar { transform: translateX(0); }` rule in `main.css` cannot override it.
- Set the mobile drawer z-index to `999 !important`, above `.book-sidebar-overlay` (`950`) and below `.book-header` (`1000`).
- Narrow `scripts/check_local_quality.sh` manuscript-sync drift checks to the markdown paths actually generated by `sync_docs_from_manuscript.py`, so directly maintained static Pages assets under `docs/assets` can be changed without failing the local quality gate.
- Scope: public Pages source is `main` `/docs`.

## Verification
- `bash scripts/check_local_quality.sh`
- `git diff --check`
- `jekyll build --source docs --destination /home/devuser/work/CodeX/booksB/.codex-local/serve/pentest-jekyll/pentest-learning-book`
- Local visual checker: `books=1 pages=10 ok=10 warn=0 fail=0`
- Direct Playwright z-index probe: `/` and `/part0_intro/01_pentest_and_vuln_assessment/` at 480/768/820/1024/1280px; closed sidebar is off-canvas, opened drawer remains above overlay and below header, desktop layout remains unchanged.

## Portfolio issue
- Part of https://github.com/itdojp/it-engineer-knowledge-architecture/issues/168
