### PR TITLE
Harden sidebar visibility transitions

### DIFF
--- a/docs/assets/css/mobile-responsive.css
+++ b/docs/assets/css/mobile-responsive.css
@@ -71,14 +71,14 @@ html {
     visibility: hidden;
     transition:
       transform 0.3s ease,
-      visibility 0s linear 0.3s;
+      visibility 0s linear 0.3s !important;
   }
 
   /* Show sidebar when toggled */
   .sidebar-toggle-checkbox:checked ~ .book-layout .book-sidebar {
     transform: translateX(0) !important;
     visibility: visible;
-    transition: transform 0.3s ease;
+    transition: transform 0.3s ease !important;
   }
   
   /* Ensure sidebar content is interactive */


### PR DESCRIPTION
## Summary
- Mark the mobile sidebar visibility-delay transition as important so later desktop sidebar rules cannot override it.
- Mark the opened-state transform transition as important for the same cascade reason.

Part of itdojp/it-engineer-knowledge-architecture#168.

## Verification
- `git diff --check`
- Static CSS guard check for important closed/open transitions and existing sidebar visibility guards.